### PR TITLE
Remake formatters on silent format

### DIFF
--- a/src/ArdorQuery.pro
+++ b/src/ArdorQuery.pro
@@ -12,6 +12,7 @@ ICON = ardorquery.icns
 SOURCES += \
         Formatters/cssformatter.cpp \
         Formatters/formatterfactory.cpp \
+        Formatters/formatterline.cpp \
         Formatters/htmlformatter.cpp \
         Formatters/jsonformatter.cpp \
         Formatters/outputformatter.cpp \
@@ -42,6 +43,7 @@ SOURCES += \
         QuickControls/backendimage.cpp \
         ViewModels/backendviewmodel.cpp \
         ViewModels/globaleventhandlermodel.cpp \
+        ViewModels/globalmouseviewmodel.cpp \
         ViewModels/httpperformerviewmodel.cpp \
         ViewModels/httprequestresultviewmodel.cpp \
         ViewModels/httprequestviewmodel.cpp \
@@ -66,6 +68,7 @@ RESOURCES += qml.qrc
 HEADERS += \
     Formatters/cssformatter.h \
     Formatters/formatterfactory.h \
+    Formatters/formatterline.h \
     Formatters/htmlformatter.h \
     Formatters/jsonformatter.h \
     Formatters/outputformatter.h \
@@ -96,6 +99,7 @@ HEADERS += \
     QuickControls/backendimage.h \
     ViewModels/backendviewmodel.h \
     ViewModels/globaleventhandlermodel.h \
+    ViewModels/globalmouseviewmodel.h \
     ViewModels/httpperformerviewmodel.h \
     ViewModels/httprequestresultviewmodel.h \
     ViewModels/httprequestviewmodel.h \

--- a/src/ArdorQuery.pro
+++ b/src/ArdorQuery.pro
@@ -41,7 +41,6 @@ SOURCES += \
         Models/postscriptresultmodel.cpp \
         Models/shortcutsection.cpp \
         QuickControls/backendimage.cpp \
-        Tests/xmlformatterunittests.cpp \
         ViewModels/backendviewmodel.cpp \
         ViewModels/globaleventhandlermodel.cpp \
         ViewModels/globalmouseviewmodel.cpp \
@@ -99,7 +98,6 @@ HEADERS += \
     Models/postscriptresultmodel.h \
     Models/shortcutsection.h \
     QuickControls/backendimage.h \
-    Tests/xmlformatterunittests.h \
     ViewModels/backendviewmodel.h \
     ViewModels/globaleventhandlermodel.h \
     ViewModels/globalmouseviewmodel.h \

--- a/src/ArdorQuery.pro
+++ b/src/ArdorQuery.pro
@@ -41,6 +41,7 @@ SOURCES += \
         Models/postscriptresultmodel.cpp \
         Models/shortcutsection.cpp \
         QuickControls/backendimage.cpp \
+        Tests/xmlformatterunittests.cpp \
         ViewModels/backendviewmodel.cpp \
         ViewModels/globaleventhandlermodel.cpp \
         ViewModels/globalmouseviewmodel.cpp \
@@ -61,6 +62,7 @@ SOURCES += \
         Tests/globalvariablesunittest.cpp \
         Tests/htmlformatterunittests.cpp \
         Tests/cssformatterunittests.cpp \
+        Tests/xmlformatterunittests.cpp \
 }
 
 RESOURCES += qml.qrc
@@ -97,6 +99,7 @@ HEADERS += \
     Models/postscriptresultmodel.h \
     Models/shortcutsection.h \
     QuickControls/backendimage.h \
+    Tests/xmlformatterunittests.h \
     ViewModels/backendviewmodel.h \
     ViewModels/globaleventhandlermodel.h \
     ViewModels/globalmouseviewmodel.h \
@@ -118,6 +121,7 @@ HEADERS += \
     Tests/globalvariablesunittest.h \
     Tests/htmlformatterunittests.h \
     Tests/cssformatterunittests.h \
+    Tests/xmlformatterunittests.h \
 }
 
 usrbininstalldesktop {

--- a/src/Formatters/cssformatter.cpp
+++ b/src/Formatters/cssformatter.cpp
@@ -84,6 +84,77 @@ QString CssFormatter::format(const QString &data)
     return m_result;
 }
 
+QMap<int, FormatterLine *> CssFormatter::silentFormat(const QString &data)
+{
+    int stackSize = 0;
+    QString currentOpenBlock = "";
+    bool isComment = false;
+    QMap<int, FormatterLine *> result;
+    FormatterLine* formatterLine = new FormatterLine(0);
+    result[0] = formatterLine;
+
+    for(auto character: data) {
+        auto latinCharacter = character.toLatin1();
+        if (latinCharacter != m_space && !isComment) formatterLine->increaseLineIterator(latinCharacter);
+
+        if (isComment && latinCharacter == m_slash && currentOpenBlock.right(1) == m_asteriks) {
+            isComment = false;
+            formatterLine->addIndex("</font>", true, false);
+            continue;
+        }
+        if (isComment) continue;
+
+        if (latinCharacter == m_blockStart) {
+            formatterLine->addIndex(" </font>", true, false);
+            formatterLine->addCustomIndex(0, "<font color=\"#8812a1\">", true);
+
+            stackSize += 1;
+            formatterLine = new FormatterLine(stackSize);
+            result[result.size()] = formatterLine;
+            continue;
+        }
+        if (latinCharacter == m_blockEnd) {
+            if (stackSize > 0) stackSize -= 1;
+            formatterLine->setOffset(stackSize);
+
+            formatterLine = new FormatterLine(stackSize);
+            result[result.size()] = formatterLine;
+
+            continue;
+        }
+
+        // make space after : character
+        if (latinCharacter == m_separator) {
+            formatterLine->increaseLineIterator(m_space[0]);
+        }
+
+        if (latinCharacter == m_endField) {
+            formatterLine->addCustomIndex(0, "<font color=\"#009dd5\">", true, false);
+            auto propertyIndex = formatterLine->line().lastIndexOf(m_separator);
+            formatterLine->addCustomIndex(propertyIndex, "</font>", true, false);
+
+            formatterLine = new FormatterLine(stackSize);
+            result[result.size()] = formatterLine;
+            continue;
+        }
+
+        if (latinCharacter == m_asteriks && !currentOpenBlock.isEmpty() && currentOpenBlock.right(1) == m_slash) {
+            isComment = true;
+            auto index = formatterLine->lineIterator() - 1;
+            formatterLine->addCustomIndex(index, "<font color=\"#008000\">", true, false);
+            continue;
+        }
+    }
+
+    //remove last redundant item
+    if (!result.isEmpty()) {
+        auto lastItem = result.value(result.size() - 1);
+        if (lastItem->isEmpty()) result.remove(result.size() - 1);
+    }
+
+    return result;
+}
+
 void CssFormatter::setOffset(int stackSize) noexcept
 {
     for (auto i = 0; i < stackSize; i++) {
@@ -101,4 +172,3 @@ void CssFormatter::fillValue(const QString &trimmedValue) noexcept
         m_result.append(trimmedValue + ";\n");
     }
 }
-

--- a/src/Formatters/cssformatter.h
+++ b/src/Formatters/cssformatter.h
@@ -43,6 +43,7 @@ public:
 
     QString format(const QString& data) override;
     QMap<int, FormatterLine*> silentFormat(const QString &data) override;
+    int silentFormatTab() override { return 4; }
 
 private:
     void setOffset(int stackSize) noexcept;

--- a/src/Formatters/cssformatter.h
+++ b/src/Formatters/cssformatter.h
@@ -42,7 +42,7 @@ public:
     CssFormatter();
 
     QString format(const QString& data) override;
-    QMap<int, FormatterLine*> silentFormat(const QString &data);
+    QMap<int, FormatterLine*> silentFormat(const QString &data) override;
 
 private:
     void setOffset(int stackSize) noexcept;

--- a/src/Formatters/cssformatter.h
+++ b/src/Formatters/cssformatter.h
@@ -16,7 +16,9 @@
 #ifndef CSSFORMATTER_H
 #define CSSFORMATTER_H
 
+#include <QMap>
 #include "outputformatter.h"
+#include "formatterline.h"
 
 class CssFormatter : public OutputFormatter
 {
@@ -31,6 +33,7 @@ private:
     const QString m_asteriks { "*" };
     const QString m_slash { "/" };
     const QString m_caretBack { "\r" };
+    const QString m_space { " " };
     const QString m_cssTab { "&nbsp;&nbsp;&nbsp;&nbsp;" };
     int m_stackSize { -1 };
     QString m_result { "" };
@@ -39,6 +42,7 @@ public:
     CssFormatter();
 
     QString format(const QString& data) override;
+    QMap<int, FormatterLine*> silentFormat(const QString &data);
 
 private:
     void setOffset(int stackSize) noexcept;

--- a/src/Formatters/formatterline.cpp
+++ b/src/Formatters/formatterline.cpp
@@ -8,6 +8,13 @@ FormatterLine::FormatterLine(int offset)
     m_offset = offset;
 }
 
+FormatterLine::~FormatterLine()
+{
+    m_line.clear();
+    m_formattedLine.clear();
+    m_indexes.clear();
+}
+
 QString FormatterLine::formattedLine(int tabSize) noexcept
 {
     if (m_alreadyFormatted) return m_formattedLine;
@@ -63,6 +70,27 @@ QString FormatterLine::formattedLine(int tabSize) noexcept
 
     m_formattedLine = result;
     m_alreadyFormatted = true;
+
+    return result;
+}
+
+QString FormatterLine::formattedLineWithSelection(int tabSize, int startSelectionPosition, int endSelectionPosition) noexcept
+{
+    auto fullCountLine = tabSize + m_line.size();
+
+    QList<QString> tabs;
+    tabs.fill("&nbsp;", tabSize);
+    QString result = tabs.join("");
+
+    auto startSelectionTag = "<span style=\"background-color: #788a8a5c; color: white;\">";
+    auto endSelectionTag = "</span>";
+
+    //need to select all line and don't need make ay other format
+    if (startSelectionPosition == 0 && endSelectionPosition == fullCountLine) {
+        result.append(startSelectionTag);
+        result.append(m_line);
+        result.append(endSelectionTag);
+    }
 
     return result;
 }

--- a/src/Formatters/formatterline.cpp
+++ b/src/Formatters/formatterline.cpp
@@ -1,0 +1,84 @@
+#include <QSet>
+#include "formatterline.h"
+
+FormatterLine::FormatterLine() {}
+
+FormatterLine::FormatterLine(int offset)
+{
+    m_offset = offset;
+}
+
+QString FormatterLine::formattedLine(int tabSize) noexcept
+{
+    if (m_alreadyFormatted) return m_formattedLine;
+
+    QString result;
+
+    QList<QString> tabs;
+    tabs.fill("&nbsp;", tabSize);
+    auto tab = tabs.join("");
+
+    for (auto i = 0; i < m_offset; i++) {
+        result.append(tab);
+    }
+
+    auto index = 0;
+
+    foreach (auto character, m_line) {
+        if (m_indexes.contains(index)) {
+            auto indexItem = m_indexes.value(index);
+            auto content = std::get<0>(indexItem);
+            auto left = std::get<1>(indexItem);
+            auto replace = std::get<2>(indexItem);
+            if (replace) {
+                result.append(content);
+            } else {
+                if (left) {
+                    result.append(content + character);
+                } else {
+                    result.append(character + content);
+                }
+            }
+        } else {
+            result.append(character);
+        }
+        index++;
+    }
+
+    m_formattedLine = result;
+    m_alreadyFormatted = true;
+
+    return result;
+}
+
+void FormatterLine::setLine(const QString &line) noexcept
+{
+    m_line = line;
+    m_indexes.clear();
+}
+
+void FormatterLine::addIndex(const QString &content, bool left, bool replace) noexcept
+{
+    auto tuple = std::make_tuple(content, left, replace);
+    m_indexes.insert(m_lineIterator, tuple);
+}
+
+void FormatterLine::changeContentInLastIndex(const QString &content) noexcept
+{
+    if (m_indexes.isEmpty()) return;
+
+    auto previousItem = m_indexes.value(m_indexes.size() - 1);
+    std::get<0>(previousItem) = content;
+    m_indexes[m_indexes.size() - 1] = previousItem;
+}
+
+void FormatterLine::increaseLineIterator(QChar character) noexcept
+{
+    m_lineIterator++;
+    m_line.append(character);
+}
+
+bool FormatterLine::isEmpty() noexcept
+{
+    return m_line.isEmpty();
+}

--- a/src/Formatters/formatterline.cpp
+++ b/src/Formatters/formatterline.cpp
@@ -73,6 +73,12 @@ void FormatterLine::addIndex(const QString &content, bool left, bool replace) no
     m_indexes.insert(m_lineIterator, tuple);
 }
 
+void FormatterLine::addCustomIndex(int index, const QString &content, bool left, bool replace) noexcept
+{
+    auto tuple = std::make_tuple(content, left, replace);
+    m_indexes.insert(index, tuple);
+}
+
 void FormatterLine::changeContentInLastIndex(const QString &content) noexcept
 {
     if (m_indexes.isEmpty()) return;

--- a/src/Formatters/formatterline.cpp
+++ b/src/Formatters/formatterline.cpp
@@ -1,6 +1,9 @@
 #include <QSet>
 #include "formatterline.h"
 
+const QString FormatterLine::StartSelectionTag = "<span style=\"background-color: #788a8a5c; color: white;\">";
+const QString FormatterLine::EndSelectionTag = "</span>";
+
 FormatterLine::FormatterLine() {}
 
 FormatterLine::FormatterLine(int offset)
@@ -82,14 +85,13 @@ QString FormatterLine::formattedLineWithSelection(int tabSize, int startSelectio
     tabs.fill("&nbsp;", tabSize);
     QString result = tabs.join("");
 
-    auto startSelectionTag = "<span style=\"background-color: #788a8a5c; color: white;\">";
-    auto endSelectionTag = "</span>";
-
     //need to select all line and don't need make ay other format
     if (startSelectionPosition == 0 && endSelectionPosition == fullCountLine) {
-        result.append(startSelectionTag);
+        result.append(FormatterLine::StartSelectionTag);
         result.append(m_line);
-        result.append(endSelectionTag);
+        result.append(FormatterLine::EndSelectionTag);
+    } else {
+
     }
 
     return result;
@@ -163,3 +165,5 @@ void FormatterLine::removeLastCharacter() noexcept
 {
     m_line.removeLast();
 }
+
+

--- a/src/Formatters/formatterline.cpp
+++ b/src/Formatters/formatterline.cpp
@@ -4,7 +4,7 @@
 
 const QString FormatterLine::StartSelectionTag = "<span style=\"background-color: #788a8a5c; color: white;\">";
 const QString FormatterLine::EndSelectionTag = "</span>";
-const QRegularExpression FormatterLine::ColorRegularExpression = QRegularExpression(R"(color=\"[A-Za-z0-9\#]{0,}\")", QRegularExpression::CaseInsensitiveOption);
+const QRegularExpression FormatterLine::ColorRegularExpression = QRegularExpression(R"(\<font\ color=\"[A-Za-z0-9\#]{0,}\"\>)", QRegularExpression::CaseInsensitiveOption);
 
 FormatterLine::FormatterLine() {}
 
@@ -89,9 +89,9 @@ QString FormatterLine::formattedLineWithSelection(int tabSize, int startSelectio
 
             //if inside selection need to clear colors from all tags
             if (index >= startSelectionPosition && index <= endSelectionPosition) {
-                if (!leftContent.isEmpty()) leftContent = leftContent.replace(FormatterLine::ColorRegularExpression, "");
-                if (!rightContent.isEmpty()) rightContent = rightContent.replace(FormatterLine::ColorRegularExpression, "");
-                if (!replaceContent.isEmpty()) replaceContent = replaceContent.replace(FormatterLine::ColorRegularExpression, "");
+                if (!leftContent.isEmpty()) leftContent = leftContent.replace(FormatterLine::ColorRegularExpression, "").replace("</font>", "");
+                if (!rightContent.isEmpty()) rightContent = rightContent.replace(FormatterLine::ColorRegularExpression, "").replace("</font>", "");
+                if (!replaceContent.isEmpty()) replaceContent = replaceContent.replace(FormatterLine::ColorRegularExpression, "").replace("</font>", "");
             }
 
             if (index == startSelectionPosition) leftContent = leftContent.insert(0, FormatterLine::StartSelectionTag);

--- a/src/Formatters/formatterline.cpp
+++ b/src/Formatters/formatterline.cpp
@@ -86,10 +86,16 @@ void FormatterLine::changeContentInLastIndex(const QString &content) noexcept
     }
 }
 
-void FormatterLine::increaseLineIterator(QChar character) noexcept
+void FormatterLine::increaseLineIterator(QChar content) noexcept
 {
     m_lineIterator++;
-    m_line.append(character);
+    m_line.append(content);
+}
+
+void FormatterLine::increaseLineIteratorString(QString content) noexcept
+{
+    m_lineIterator += content.size();
+    m_line.append(content);
 }
 
 bool FormatterLine::isEmpty() noexcept

--- a/src/Formatters/formatterline.cpp
+++ b/src/Formatters/formatterline.cpp
@@ -62,9 +62,10 @@ QString FormatterLine::formattedLine(int tabSize) noexcept
 
 QString FormatterLine::formattedLineWithSelection(int tabSize, int startSelectionPosition, int endSelectionPosition) noexcept
 {
+    auto countTabs = tabSize * m_offset;
     QList<QString> tabs;
-    tabs.reserve(tabSize);
-    tabs.fill("&nbsp;", tabSize);
+    tabs.reserve(countTabs);
+    tabs.fill("&nbsp;", countTabs);
     QString result = tabs.join("");
 
     if (endSelectionPosition == -1) endSelectionPosition = m_line.size() - 1;

--- a/src/Formatters/formatterline.cpp
+++ b/src/Formatters/formatterline.cpp
@@ -69,6 +69,11 @@ QString FormatterLine::formattedLineWithSelection(int tabSize, int startSelectio
     QString result = tabs.join("");
 
     if (endSelectionPosition == -1) endSelectionPosition = m_line.size() - 1;
+    if (endSelectionPosition < startSelectionPosition) {
+        auto tempEndSelection = startSelectionPosition;
+        startSelectionPosition = endSelectionPosition;
+        endSelectionPosition = tempEndSelection;
+    }
 
     //need to select all line and don't need make ay other format
     auto index = 0;

--- a/src/Formatters/formatterline.h
+++ b/src/Formatters/formatterline.h
@@ -1,7 +1,7 @@
 #ifndef FORMATTERLINE_H
 #define FORMATTERLINE_H
 
-#include <QMap>
+#include <QMultiMap>
 #include <QString>
 
 class FormatterLine
@@ -11,7 +11,7 @@ private:
     QString m_formattedLine { "" };
     bool m_alreadyFormatted { false };
     int m_offset { 0 };
-    QMap<int, std::tuple<QString, bool, bool>> m_indexes { QMap<int, std::tuple<QString, bool, bool>>() };
+    QMultiMap<int, std::tuple<QString, bool, bool>> m_indexes { QMultiMap<int, std::tuple<QString, bool, bool>>() };
     int m_lineIterator { -1 };
 
 public:

--- a/src/Formatters/formatterline.h
+++ b/src/Formatters/formatterline.h
@@ -29,6 +29,8 @@ public:
 
     void addIndex(const QString& content, bool left, bool replace = false) noexcept;
 
+    void addCustomIndex(int index, const QString& content, bool left, bool replace = false) noexcept;
+
     void changeContentInLastIndex(const QString& content) noexcept;
 
     void increaseLineIterator(QChar character) noexcept;
@@ -36,6 +38,8 @@ public:
     void increaseLineIteratorString(QString content) noexcept;
 
     bool isEmpty() noexcept;
+
+    int lineIterator() const noexcept { return m_lineIterator; }
 
 };
 

--- a/src/Formatters/formatterline.h
+++ b/src/Formatters/formatterline.h
@@ -1,0 +1,40 @@
+#ifndef FORMATTERLINE_H
+#define FORMATTERLINE_H
+
+#include <QMap>
+#include <QString>
+
+class FormatterLine
+{
+private:
+    QString m_line { "" };
+    QString m_formattedLine { "" };
+    bool m_alreadyFormatted { false };
+    int m_offset { 0 };
+    QMap<int, std::tuple<QString, bool, bool>> m_indexes { QMap<int, std::tuple<QString, bool, bool>>() };
+    int m_lineIterator { -1 };
+
+public:
+    FormatterLine();
+
+    FormatterLine(int offset);
+
+    QString line() const noexcept { return m_line; }
+
+    QString formattedLine(int tabSize = 1) noexcept;
+
+    void setLine(const QString& line) noexcept;
+
+    void setOffset(int offset) noexcept { m_offset = offset; }
+
+    void addIndex(const QString& content, bool left, bool replace = false) noexcept;
+
+    void changeContentInLastIndex(const QString& content) noexcept;
+
+    void increaseLineIterator(QChar character) noexcept;
+
+    bool isEmpty() noexcept;
+
+};
+
+#endif // FORMATTERLINE_H

--- a/src/Formatters/formatterline.h
+++ b/src/Formatters/formatterline.h
@@ -33,6 +33,8 @@ public:
 
     void increaseLineIterator(QChar character) noexcept;
 
+    void increaseLineIteratorString(QString content) noexcept;
+
     bool isEmpty() noexcept;
 
 };

--- a/src/Formatters/formatterline.h
+++ b/src/Formatters/formatterline.h
@@ -39,6 +39,8 @@ public:
 
     void setOffset(int offset) noexcept { m_offset = offset; }
 
+    int offset() const noexcept { return m_offset; }
+
     void addIndex(const QString& content, bool left, bool replace = false) noexcept;
 
     void addCustomIndex(int index, const QString& content, bool left, bool replace = false, bool toTop = false) noexcept;

--- a/src/Formatters/formatterline.h
+++ b/src/Formatters/formatterline.h
@@ -8,6 +8,7 @@ class FormatterLine
 {
 private:
     QString m_line { "" };
+    QString m_lineWithOffset { "" };
     QString m_formattedLine { "" };
     bool m_alreadyFormatted { false };
     int m_offset { 0 };
@@ -15,6 +16,7 @@ private:
     int m_lineIterator { -1 };
     static const QString StartSelectionTag;
     static const QString EndSelectionTag;
+    static const QRegularExpression ColorRegularExpression;
 
 public:
     FormatterLine();
@@ -25,9 +27,13 @@ public:
 
     QString line() const noexcept { return m_line; }
 
+    QString lineWithOffset() const noexcept { return m_lineWithOffset; }
+
     QString formattedLine(int tabSize = 1) noexcept;
 
     QString formattedLineWithSelection(int tabSize, int startSelectionPosition, int endSelectionPosition) noexcept;
+
+    void fillLineWithOffset(int tabSize = 1) noexcept;
 
     void setLine(const QString& line) noexcept;
 
@@ -50,6 +56,9 @@ public:
     bool containsCharacter(QChar character) const noexcept;
 
     void removeLastCharacter() noexcept;
+
+private:
+    std::tuple<QString,QString,QString> getContents(const QList<std::tuple<QString,bool,bool>>& items);
 
 };
 

--- a/src/Formatters/formatterline.h
+++ b/src/Formatters/formatterline.h
@@ -13,6 +13,8 @@ private:
     int m_offset { 0 };
     QMultiMap<int, std::tuple<QString, bool, bool>> m_indexes { QMultiMap<int, std::tuple<QString, bool, bool>>() };
     int m_lineIterator { -1 };
+    static const QString StartSelectionTag;
+    static const QString EndSelectionTag;
 
 public:
     FormatterLine();

--- a/src/Formatters/formatterline.h
+++ b/src/Formatters/formatterline.h
@@ -29,7 +29,7 @@ public:
 
     void addIndex(const QString& content, bool left, bool replace = false) noexcept;
 
-    void addCustomIndex(int index, const QString& content, bool left, bool replace = false) noexcept;
+    void addCustomIndex(int index, const QString& content, bool left, bool replace = false, bool toTop = false) noexcept;
 
     void changeContentInLastIndex(const QString& content) noexcept;
 
@@ -40,6 +40,10 @@ public:
     bool isEmpty() noexcept;
 
     int lineIterator() const noexcept { return m_lineIterator; }
+
+    bool containsCharacter(QChar character) const noexcept;
+
+    void removeLastCharacter() noexcept;
 
 };
 

--- a/src/Formatters/formatterline.h
+++ b/src/Formatters/formatterline.h
@@ -19,9 +19,13 @@ public:
 
     FormatterLine(int offset);
 
+    ~FormatterLine();
+
     QString line() const noexcept { return m_line; }
 
     QString formattedLine(int tabSize = 1) noexcept;
+
+    QString formattedLineWithSelection(int tabSize, int startSelectionPosition, int endSelectionPosition) noexcept;
 
     void setLine(const QString& line) noexcept;
 

--- a/src/Formatters/htmlformatter.cpp
+++ b/src/Formatters/htmlformatter.cpp
@@ -309,11 +309,6 @@ void HtmlFormatter::formatTagSilent(QString &tag, QMap<int, FormatterLine*> resu
             closedPartStarted = true;
         }
 
-        /*if (latinCharacter == m_closedTag) {
-            m_result.append("/");
-            continue;
-        }*/
-
         if (latinCharacter == m_attributeDecorator) {
             if (stringStarted) {
                 stringStarted = false;
@@ -328,11 +323,9 @@ void HtmlFormatter::formatTagSilent(QString &tag, QMap<int, FormatterLine*> resu
         if (!tagNameStarted && !attributeStarted) {
             attributeStarted = true;
             m_formatterLine->addIndex("<font color=\"#994500\">", true, false);
-            //m_result.append("<font color=\"#994500\">");
         }
     }
 
-    //m_result.append("</font>\n");
     m_formatterLine->increaseLineIterator('>');
     m_formatterLine->addIndex("&gt;</font>", false, true);
 }
@@ -353,7 +346,6 @@ void HtmlFormatter::formatTagWithOffsetSilent(QString &tag, QMap<int, FormatterL
 
         m_formatterLine = new FormatterLine(m_stackSize);
         result[result.size()] = m_formatterLine;
-        //m_result.append("<font color=\"lightgray\">" + tag.replace("<", "&lt;").replace(">", "&gt;") + "</font>\n");
         return;
     }
 
@@ -366,8 +358,6 @@ void HtmlFormatter::formatTagWithOffsetSilent(QString &tag, QMap<int, FormatterL
 
         m_formatterLine = new FormatterLine(m_stackSize);
         result[result.size()] = m_formatterLine;
-        /*setOffset();
-        m_result.append("<font color=\"#008000\">" + tag.replace("<", "&lt;").replace(">", "&gt;") + "</font>\n");*/
         return;
     }
 

--- a/src/Formatters/htmlformatter.cpp
+++ b/src/Formatters/htmlformatter.cpp
@@ -81,7 +81,7 @@ QString HtmlFormatter::format(const QString &data)
 QMap<int, FormatterLine *> HtmlFormatter::silentFormat(const QString &data)
 {
     QMap<int, FormatterLine*> result;
-    m_stackSize = -1;
+    m_stackSize = 0;
     QString currentFullTag = "";
     bool tagStarted = false;
     bool contentStarted = false;
@@ -96,9 +96,8 @@ QMap<int, FormatterLine *> HtmlFormatter::silentFormat(const QString &data)
             currentFullTag = latinCharacter;
             if (contentStarted) {
                 contentStarted = false;
-                //m_result.append("\n");
-                m_formatterLine = new FormatterLine(m_stackSize);
 
+                m_formatterLine = new FormatterLine(m_stackSize);
                 result[result.size()] = m_formatterLine;
             }
             continue;
@@ -113,15 +112,11 @@ QMap<int, FormatterLine *> HtmlFormatter::silentFormat(const QString &data)
         }
 
         if (!tagStarted && latinCharacter != m_newline && latinCharacter != m_caretBack && latinCharacter != m_space && latinCharacter != m_tabulator) {
-            if (!contentStarted) {
-                contentStarted = true;
-                //setOffset();
-            }
-            //m_result.append(character);
+            if (!contentStarted) contentStarted = true;
+
             m_formatterLine->increaseLineIterator(character);
         }
         if (latinCharacter == m_space && contentStarted) {
-            //m_result.append(m_space);
             m_formatterLine->increaseLineIterator(m_space[0]);
         }
         if (tagStarted && latinCharacter != m_newline) currentFullTag.append(character);
@@ -377,20 +372,20 @@ void HtmlFormatter::formatTagWithOffsetSilent(QString &tag, QMap<int, FormatterL
     }
 
     if (closedTag) {
-        if (!selfClosedTag) m_stackSize -= 1;
-        //setOffset();
+        if (!selfClosedTag) {
+            m_stackSize -= 1;
+            m_formatterLine->setOffset(m_stackSize);
+        }
         formatTagSilent(tag, result);
 
         m_formatterLine = new FormatterLine(m_stackSize);
         result[result.size()] = m_formatterLine;
     } else if (selfClosedTag) {
-        //setOffset();
         formatTagSilent(tag, result);
 
         m_formatterLine = new FormatterLine(m_stackSize);
         result[result.size()] = m_formatterLine;
     } else {
-        //setOffset();
         formatTagSilent(tag, result);
         m_stackSize += 1;
 

--- a/src/Formatters/htmlformatter.cpp
+++ b/src/Formatters/htmlformatter.cpp
@@ -383,7 +383,6 @@ void HtmlFormatter::formatTagWithOffsetSilent(QString &tag, QMap<int, FormatterL
 
         m_formatterLine = new FormatterLine(m_stackSize);
         result[result.size()] = m_formatterLine;
-        qDebug() << result.size();
     } else if (selfClosedTag) {
         //setOffset();
         formatTagSilent(tag, result);

--- a/src/Formatters/htmlformatter.cpp
+++ b/src/Formatters/htmlformatter.cpp
@@ -78,6 +78,64 @@ QString HtmlFormatter::format(const QString &data)
     return resultPass;
 }
 
+QMap<int, FormatterLine *> HtmlFormatter::silentFormat(const QString &data)
+{
+    QMap<int, FormatterLine*> result;
+    m_stackSize = -1;
+    QString currentFullTag = "";
+    bool tagStarted = false;
+    bool contentStarted = false;
+    m_formatterLine = new FormatterLine(0);
+    result[0] = m_formatterLine;
+
+    for(auto character: data) {
+        auto latinCharacter = character.toLatin1();
+
+        if (latinCharacter == m_tagStart && !tagStarted) {
+            tagStarted = true;
+            currentFullTag = latinCharacter;
+            if (contentStarted) {
+                contentStarted = false;
+                //m_result.append("\n");
+                m_formatterLine = new FormatterLine(m_stackSize);
+
+                result[result.size()] = m_formatterLine;
+            }
+            continue;
+        }
+
+        if (latinCharacter == m_tagEnd && tagStarted) {
+            tagStarted = false;
+            currentFullTag.append(character);
+            formatTagWithOffsetSilent(currentFullTag, result);
+            currentFullTag.clear();
+            continue;
+        }
+
+        if (!tagStarted && latinCharacter != m_newline && latinCharacter != m_caretBack && latinCharacter != m_space && latinCharacter != m_tabulator) {
+            if (!contentStarted) {
+                contentStarted = true;
+                //setOffset();
+            }
+            //m_result.append(character);
+            m_formatterLine->increaseLineIterator(character);
+        }
+        if (latinCharacter == m_space && contentStarted) {
+            //m_result.append(m_space);
+            m_formatterLine->increaseLineIterator(m_space[0]);
+        }
+        if (tagStarted && latinCharacter != m_newline) currentFullTag.append(character);
+    }
+
+    //remove last redundant item
+    if (!result.isEmpty()) {
+        auto lastItem = result.value(result.size() - 1);
+        if (lastItem->isEmpty()) result.remove(result.size() - 1);
+    }
+
+    return result;
+}
+
 bool HtmlFormatter::isSelfClosedTag(const QString &tag)
 {
     if (tag[tag.length() - 2] == m_closedTag) return true;
@@ -198,6 +256,148 @@ void HtmlFormatter::formatTag(QString &tag)
     }
 
     m_result.append("</font>\n");
+}
+
+void HtmlFormatter::formatTagSilent(QString &tag, QMap<int, FormatterLine*> result)
+{
+    auto contentIndex = tag.indexOf(m_space);
+    // it means tag without attributes, and we can use shortcut
+    if (contentIndex == -1) {
+        m_formatterLine->increaseLineIterator('<');
+        m_formatterLine->addIndex("<font color=\"#8812a1\">&lt;", false, true);
+        m_formatterLine->increaseLineIteratorString(tag.replace(">", "").replace("<", ""));
+        m_formatterLine->increaseLineIterator('>');
+        m_formatterLine->addIndex("&gt;</font>", false, true);
+
+        return;
+    }
+
+    bool attributeStarted = false;
+    bool stringStarted = false;
+    bool tagNameStarted = true;
+    bool closedPartStarted = false;
+
+    m_formatterLine->increaseLineIterator('<');
+    m_formatterLine->addIndex("<font color=\"#8812a1\">&lt;", false, true);
+
+    auto processedTag = tag.mid(1);
+    processedTag = processedTag.mid(0, processedTag.size() - 1);
+
+    foreach(auto character, processedTag) {
+        auto latinCharacter = character.toLatin1();
+
+        m_formatterLine->increaseLineIterator(latinCharacter);
+
+        if (latinCharacter == m_space && !stringStarted) {
+            if (attributeStarted) {
+                attributeStarted = false;
+                m_formatterLine->addIndex("</font>", true, false);
+            }
+            if (tagNameStarted) {
+                tagNameStarted = false;
+                m_formatterLine->addIndex("</font>", true, false);
+            }
+        }
+
+        if (latinCharacter == m_tagStart) {
+            m_formatterLine->addIndex("&lt;", false, true);
+            continue;
+        }
+
+        if (latinCharacter == m_tagEnd) {
+            m_formatterLine->addIndex("&gt;", false, true);
+            continue;
+        }
+
+        if (!closedPartStarted && !attributeStarted && (latinCharacter == m_tagEnd || latinCharacter == m_closedTag)) {
+            m_formatterLine->addIndex("</font><font color=\"#8812a1\">", true, false);
+            closedPartStarted = true;
+        }
+
+        /*if (latinCharacter == m_closedTag) {
+            m_result.append("/");
+            continue;
+        }*/
+
+        if (latinCharacter == m_attributeDecorator) {
+            if (stringStarted) {
+                stringStarted = false;
+                m_formatterLine->addIndex("&quot;</font>", false, true);
+            } else {
+                stringStarted = true;
+                m_formatterLine->addIndex("<font color=\"#2222dd\">&quot;", false, true);
+            }
+            continue;
+        }
+
+        if (!tagNameStarted && !attributeStarted) {
+            attributeStarted = true;
+            m_formatterLine->addIndex("<font color=\"#994500\">", true, false);
+            //m_result.append("<font color=\"#994500\">");
+        }
+    }
+
+    //m_result.append("</font>\n");
+    m_formatterLine->increaseLineIterator('>');
+    m_formatterLine->addIndex("&gt;</font>", false, true);
+}
+
+void HtmlFormatter::formatTagWithOffsetSilent(QString &tag, QMap<int, FormatterLine*>& result)
+{
+    auto closedTag = tag[1] == m_closedTag;
+    auto selfClosedTag = isSelfClosedTag(tag);
+    auto header = tag.startsWith(m_doctype) || tag.startsWith(m_upperDoctype);
+    auto comment = tag.startsWith(m_comment);
+
+    if (header) {
+        m_formatterLine->increaseLineIterator('<');
+        m_formatterLine->addIndex("<font color=\"lightgray\">&lt;", false, true);
+        m_formatterLine->increaseLineIteratorString(tag.replace(">", "").replace("<", ""));
+        m_formatterLine->increaseLineIterator('>');
+        m_formatterLine->addIndex("&gt;</font>", false, true);
+
+        m_formatterLine = new FormatterLine(m_stackSize);
+        result[result.size()] = m_formatterLine;
+        //m_result.append("<font color=\"lightgray\">" + tag.replace("<", "&lt;").replace(">", "&gt;") + "</font>\n");
+        return;
+    }
+
+    if (comment) {
+        m_formatterLine->increaseLineIterator('<');
+        m_formatterLine->addIndex("<font color=\"#008000\">&lt;", false, true);
+        m_formatterLine->increaseLineIteratorString(tag.replace(">", "").replace("<", ""));
+        m_formatterLine->increaseLineIterator('>');
+        m_formatterLine->addIndex("&gt;</font>", false, true);
+
+        m_formatterLine = new FormatterLine(m_stackSize);
+        result[result.size()] = m_formatterLine;
+        /*setOffset();
+        m_result.append("<font color=\"#008000\">" + tag.replace("<", "&lt;").replace(">", "&gt;") + "</font>\n");*/
+        return;
+    }
+
+    if (closedTag) {
+        if (!selfClosedTag) m_stackSize -= 1;
+        //setOffset();
+        formatTagSilent(tag, result);
+
+        m_formatterLine = new FormatterLine(m_stackSize);
+        result[result.size()] = m_formatterLine;
+        qDebug() << result.size();
+    } else if (selfClosedTag) {
+        //setOffset();
+        formatTagSilent(tag, result);
+
+        m_formatterLine = new FormatterLine(m_stackSize);
+        result[result.size()] = m_formatterLine;
+    } else {
+        //setOffset();
+        formatTagSilent(tag, result);
+        m_stackSize += 1;
+
+        m_formatterLine = new FormatterLine(m_stackSize);
+        result[result.size()] = m_formatterLine;
+    }
 }
 
 void HtmlFormatter::setOffset(int tabSize) noexcept

--- a/src/Formatters/htmlformatter.h
+++ b/src/Formatters/htmlformatter.h
@@ -48,7 +48,7 @@ public:
     HtmlFormatter();
 
     QString format(const QString& data) override;
-    QMap<int, FormatterLine*> silentFormat(const QString &data);
+    QMap<int, FormatterLine*> silentFormat(const QString &data) override;
     bool isSelfClosedTag(const QString &tag);
     void formatTagWithOffset(QString &tag);
     void formatTag(QString &tag);

--- a/src/Formatters/htmlformatter.h
+++ b/src/Formatters/htmlformatter.h
@@ -17,7 +17,9 @@
 #define HTMLFORMATTER_H
 
 #include <QSet>
+#include <QMap>
 #include "outputformatter.h"
+#include "formatterline.h"
 
 class HtmlFormatter : public OutputFormatter
 {
@@ -40,14 +42,18 @@ private:
     const QString m_tabulator { "\t" };
     int m_stackSize { -1 };
     QString m_result { "" };
+    FormatterLine* m_formatterLine { nullptr };
 
 public:
     HtmlFormatter();
 
     QString format(const QString& data) override;
+    QMap<int, FormatterLine*> silentFormat(const QString &data);
     bool isSelfClosedTag(const QString &tag);
     void formatTagWithOffset(QString &tag);
     void formatTag(QString &tag);
+    void formatTagSilent(QString &tag, QMap<int, FormatterLine*> result);
+    void formatTagWithOffsetSilent(QString &tag, QMap<int, FormatterLine*>& result);
     void setOffset(int tabSize = 4) noexcept;
 };
 

--- a/src/Formatters/htmlformatter.h
+++ b/src/Formatters/htmlformatter.h
@@ -49,6 +49,7 @@ public:
 
     QString format(const QString& data) override;
     QMap<int, FormatterLine*> silentFormat(const QString &data) override;
+    int silentFormatTab() override { return 4; }
     bool isSelfClosedTag(const QString &tag);
     void formatTagWithOffset(QString &tag);
     void formatTag(QString &tag);

--- a/src/Formatters/jsonformatter.cpp
+++ b/src/Formatters/jsonformatter.cpp
@@ -143,7 +143,7 @@ QMap<int, FormatterLine*> JsonFormatter::silentFormat(const QString &data)
 
         auto isSpecialCharacters = m_space == latinCharacter || m_tabulator == latinCharacter || m_newlineDivider == latinCharacter;
         auto isDigit = digitStarted && m_digits.contains(latinCharacter);
-        auto isNewLineCharacters = m_object.indexOf(latinCharacter) == 1 || m_comma == latinCharacter;
+        auto isNewLineCharacters = m_object.indexOf(latinCharacter) == 1 || m_comma == latinCharacter || m_array.indexOf(latinCharacter) == 1;
         if ((isDigit || !isSpecialCharacters) || (isSpecialCharacters && stringStarted)) {
             if (!isNewLineCharacters) {
                 formatterLine->increaseLineIterator(character);
@@ -173,6 +173,7 @@ QMap<int, FormatterLine*> JsonFormatter::silentFormat(const QString &data)
                 stackSize -= 1;
                 formatterLine = new FormatterLine(stackSize);
                 result[result.size()] = formatterLine;
+                formatterLine->increaseLineIterator(']');
                 formatterLine->addIndex( "<font color=\"black\">]</font>", false, true);
             }
             continue;

--- a/src/Formatters/jsonformatter.cpp
+++ b/src/Formatters/jsonformatter.cpp
@@ -125,6 +125,134 @@ QString JsonFormatter::format(const QString &data)
     return result;
 }
 
+QMap<int, FormatterLine*> JsonFormatter::silentFormat(const QString &data)
+{
+    QMap<int, FormatterLine*> result;
+    int stackSize = 0;
+    bool stringStarted = false;
+    int iterator = -1;
+    int skipNextCharacters = 0;
+    bool digitStarted = false;
+    FormatterLine* formatterLine = new FormatterLine(0);
+    result[0] = formatterLine;
+
+    for (auto character: data) {
+        auto latinCharacter = character.toLatin1();
+
+        iterator++;
+
+        auto isSpecialCharacters = m_space == latinCharacter || m_tabulator == latinCharacter || m_newlineDivider == latinCharacter;
+        auto isDigit = digitStarted && m_digits.contains(latinCharacter);
+        auto isNewLineCharacters = m_object.indexOf(latinCharacter) == 1 || m_comma == latinCharacter;
+        if ((isDigit || !isSpecialCharacters) || (isSpecialCharacters && stringStarted)) {
+            if (!isNewLineCharacters) {
+                formatterLine->increaseLineIterator(character);
+            }
+        }
+
+        if (skipNextCharacters > 0) {
+            skipNextCharacters--;
+            continue;
+        }
+
+        if (stringStarted && m_string != latinCharacter) continue;
+        if (digitStarted && !m_digits.contains(latinCharacter)) {
+            formatterLine->addIndex("</font>", false, false);
+            digitStarted = false;
+        }
+        auto charIndex = m_array.indexOf(latinCharacter);
+        if (charIndex > -1) {
+            if (charIndex == 0) {
+                formatterLine->addIndex("<font color=\"black\">[</font>", false, true);
+                stackSize += 1;
+
+                formatterLine = new FormatterLine(stackSize);
+                result[result.size()] = formatterLine;
+            }
+            if (charIndex == 1) {
+                stackSize -= 1;
+                formatterLine = new FormatterLine(stackSize);
+                result[result.size()] = formatterLine;
+                formatterLine->addIndex( "<font color=\"black\">]</font>", false, true);
+            }
+            continue;
+        }
+
+        charIndex = m_object.indexOf(latinCharacter);
+        if (charIndex > -1) {
+            if (charIndex == 0) {
+                formatterLine->addIndex("<font color=\"black\">{</font>", false, true);
+                stackSize += 1;
+
+                formatterLine = new FormatterLine(stackSize);
+                result[result.size()] = formatterLine;
+            }
+            if (charIndex == 1) {
+                stackSize -= 1;
+
+                formatterLine = new FormatterLine(stackSize);
+                result[result.size()] = formatterLine;
+                formatterLine->increaseLineIterator('}');
+                formatterLine->addIndex("<font color=\"black\">}</font>", false, true);                
+
+                formatterLine = new FormatterLine(stackSize);
+                result[result.size()] = formatterLine;
+            }
+            continue;
+        }
+
+        if (m_string == latinCharacter) {
+            stringStarted = !stringStarted;
+
+            if (stringStarted) {
+                formatterLine->addIndex(m_plainStringStart, false, true);
+            } else {
+                auto isProperty = iterator < data.size() - 1 ? data[iterator + 1].toLatin1() == m_colon : false;
+                if (isProperty) formatterLine->changeContentInLastIndex(m_propertyStringStart);
+
+                formatterLine->addIndex("</font>", false, false);
+            }
+
+            continue;
+        }
+
+        if (m_backslash == latinCharacter && stringStarted) {
+            if (iterator < data.size()) {
+                auto nextCharacter = data[iterator + 1].toLatin1();
+                if (nextCharacter == m_reverse || nextCharacter == m_newline) skipNextCharacters += 1;
+                if (nextCharacter == m_unicode) skipNextCharacters += 5;
+            }
+            continue;
+        }
+
+        if (m_comma == latinCharacter && !stringStarted) {
+            formatterLine->increaseLineIterator(',');
+            formatterLine = new FormatterLine(stackSize);
+            result[result.size()] = formatterLine;
+            continue;
+        }
+
+        if (m_colon == latinCharacter && !stringStarted) {
+            formatterLine->addIndex(":&nbsp;", false, true);
+            continue;
+        }
+
+        if (!stringStarted && !digitStarted && m_startDigits.contains(latinCharacter)) {
+            formatterLine->addIndex("<font color=\"#cc7700\">", true);
+            digitStarted = true;
+            continue;
+        }
+    }
+
+    //remove last redundant item
+    if (!result.isEmpty()) {
+        auto lastItem = result.value(result.size() - 1);
+        if (lastItem->isEmpty()) result.remove(result.size() - 1);
+    }
+
+    return result;
+}
+
 void JsonFormatter::setOffset(int stackSize, QString& target, bool newLine) noexcept
 {
     if (newLine) target.append("\n");

--- a/src/Formatters/jsonformatter.h
+++ b/src/Formatters/jsonformatter.h
@@ -18,6 +18,8 @@
 
 #include "outputformatter.h"
 
+#include "formatterline.h"
+
 class JsonFormatter: public OutputFormatter
 {
 private:
@@ -43,6 +45,7 @@ public:
     JsonFormatter();
 
     QString format(const QString& data) override;
+    QMap<int, FormatterLine*> silentFormat(const QString& data); //override;
     void setOffset(int stackSize, QString& target, bool newLine = false) noexcept;
 };
 

--- a/src/Formatters/jsonformatter.h
+++ b/src/Formatters/jsonformatter.h
@@ -17,7 +17,6 @@
 #define JSONFORMATTER_H
 
 #include "outputformatter.h"
-
 #include "formatterline.h"
 
 class JsonFormatter: public OutputFormatter

--- a/src/Formatters/jsonformatter.h
+++ b/src/Formatters/jsonformatter.h
@@ -45,6 +45,7 @@ public:
 
     QString format(const QString& data) override;
     QMap<int, FormatterLine*> silentFormat(const QString& data) override;
+    int silentFormatTab() override { return 4; }
     void setOffset(int stackSize, QString& target, bool newLine = false) noexcept;
 };
 

--- a/src/Formatters/jsonformatter.h
+++ b/src/Formatters/jsonformatter.h
@@ -44,7 +44,7 @@ public:
     JsonFormatter();
 
     QString format(const QString& data) override;
-    QMap<int, FormatterLine*> silentFormat(const QString& data); //override;
+    QMap<int, FormatterLine*> silentFormat(const QString& data) override;
     void setOffset(int stackSize, QString& target, bool newLine = false) noexcept;
 };
 

--- a/src/Formatters/outputformatter.cpp
+++ b/src/Formatters/outputformatter.cpp
@@ -35,3 +35,8 @@ QMap<int, FormatterLine *> OutputFormatter::silentFormat(const QString &data)
     QMap<int, FormatterLine *> result;
     return result;
 }
+
+int OutputFormatter::silentFormatTab()
+{
+    return 0;
+}

--- a/src/Formatters/outputformatter.cpp
+++ b/src/Formatters/outputformatter.cpp
@@ -25,3 +25,13 @@ QString OutputFormatter::format(const QString &data)
     //the actual formatting needs to be done in descendants
     return data;
 }
+
+QMap<int, FormatterLine *> OutputFormatter::silentFormat(const QString &data)
+{
+    Q_UNUSED(data);
+
+    //In the base class, simple return inputs
+    //the actual formatting needs to be done in descendants
+    QMap<int, FormatterLine *> result;
+    return result;
+}

--- a/src/Formatters/outputformatter.h
+++ b/src/Formatters/outputformatter.h
@@ -27,6 +27,7 @@ public:
 
     virtual QString format(const QString& data);
     virtual QMap<int, FormatterLine*> silentFormat(const QString& data);
+    virtual int silentFormatTab();
 };
 
 #endif // OUTPUTFORMATTER_H

--- a/src/Formatters/outputformatter.h
+++ b/src/Formatters/outputformatter.h
@@ -18,7 +18,7 @@
 
 #include <QString>
 #include <QMap>
-//#include "formatterline.h"
+#include "formatterline.h"
 
 class OutputFormatter
 {
@@ -26,7 +26,7 @@ public:
     OutputFormatter();
 
     virtual QString format(const QString& data);
-    //virtual QMap<int, FormatterLine*> silentFormat(const QString& data);
+    virtual QMap<int, FormatterLine*> silentFormat(const QString& data);
 };
 
 #endif // OUTPUTFORMATTER_H

--- a/src/Formatters/outputformatter.h
+++ b/src/Formatters/outputformatter.h
@@ -17,6 +17,8 @@
 #define OUTPUTFORMATTER_H
 
 #include <QString>
+#include <QMap>
+//#include "formatterline.h"
 
 class OutputFormatter
 {
@@ -24,6 +26,7 @@ public:
     OutputFormatter();
 
     virtual QString format(const QString& data);
+    //virtual QMap<int, FormatterLine*> silentFormat(const QString& data);
 };
 
 #endif // OUTPUTFORMATTER_H

--- a/src/Formatters/plaintextformatter.cpp
+++ b/src/Formatters/plaintextformatter.cpp
@@ -31,3 +31,36 @@ QString PlainTextFormatter::format(const QString &data)
 
     return result;
 }
+
+QMap<int, FormatterLine *> PlainTextFormatter::silentFormat(const QString &data)
+{
+    QMap<int, FormatterLine *> result;
+    FormatterLine* formatterLine = new FormatterLine(0);
+    result[0] = formatterLine;
+
+    auto lineWidth = 0;
+
+    for(auto character: data) {
+        auto latinCharacter = character.toLatin1();
+        formatterLine->increaseLineIterator(latinCharacter);
+
+        if (latinCharacter == m_newline || latinCharacter == m_caretBack) {
+            formatterLine = new FormatterLine(0);
+            result[result.size()] = formatterLine;
+
+            lineWidth = 0;
+            continue;
+        }
+
+        if (lineWidth >= 200) {
+            formatterLine = new FormatterLine(0);
+            result[result.size()] = formatterLine;
+
+            lineWidth = 0;
+        } else {
+            lineWidth += 1;
+        }
+    }
+
+    return result;
+}

--- a/src/Formatters/plaintextformatter.h
+++ b/src/Formatters/plaintextformatter.h
@@ -1,7 +1,9 @@
 #ifndef PLAINTEXTFORMATTER_H
 #define PLAINTEXTFORMATTER_H
 
+#include <QMap>
 #include "outputformatter.h"
+#include "formatterline.h"
 
 class PlainTextFormatter : public OutputFormatter
 {
@@ -14,6 +16,7 @@ public:
     PlainTextFormatter();
 
     QString format(const QString& data) override;
+    QMap<int, FormatterLine*> silentFormat(const QString &data);
 };
 
 #endif // PLAINTEXTFORMATTER_H

--- a/src/Formatters/plaintextformatter.h
+++ b/src/Formatters/plaintextformatter.h
@@ -16,7 +16,7 @@ public:
     PlainTextFormatter();
 
     QString format(const QString& data) override;
-    QMap<int, FormatterLine*> silentFormat(const QString &data);
+    QMap<int, FormatterLine*> silentFormat(const QString &data) override;
 };
 
 #endif // PLAINTEXTFORMATTER_H

--- a/src/Formatters/plaintextformatter.h
+++ b/src/Formatters/plaintextformatter.h
@@ -17,6 +17,7 @@ public:
 
     QString format(const QString& data) override;
     QMap<int, FormatterLine*> silentFormat(const QString &data) override;
+    int silentFormatTab() override { return 1; }
 };
 
 #endif // PLAINTEXTFORMATTER_H

--- a/src/Formatters/xmlformatter.cpp
+++ b/src/Formatters/xmlformatter.cpp
@@ -306,7 +306,10 @@ void XmlFormatter::formatTagSilent(QString &tag)
     m_formatterLine->increaseLineIterator('<');
     m_formatterLine->addIndex("<font color=\"#8812a1\">&lt;", false, true);
 
-    foreach(auto character, tag) {
+    auto processedTag = tag.mid(1);
+    processedTag = processedTag.mid(0, processedTag.size() - 1);
+
+    foreach(auto character, processedTag) {
         auto latinCharacter = character.toLatin1();
 
         m_formatterLine->increaseLineIterator(latinCharacter);
@@ -349,7 +352,7 @@ void XmlFormatter::formatTagSilent(QString &tag)
             continue;
         }
 
-        if (!attributeStarted) {
+        if (!tagNameStarted && !attributeStarted) {
             attributeStarted = true;
             m_formatterLine->addIndex("<font color=\"#994500\">", true, false);
         }

--- a/src/Formatters/xmlformatter.cpp
+++ b/src/Formatters/xmlformatter.cpp
@@ -23,15 +23,12 @@ XmlFormatter::XmlFormatter()
 QString XmlFormatter::format(const QString &data)
 {
     QString currentFullTag = "";
-    int iterator = -1;
     m_result.clear();
     m_stackSize = 0;
     bool tagStarted = false;
     bool contentStarted = false;
 
     for(auto character: data) {
-        iterator++;
-
         auto latinCharacter = character.toLatin1();
 
         if (latinCharacter == m_tagStart && !tagStarted) {
@@ -68,6 +65,61 @@ QString XmlFormatter::format(const QString &data)
     return resultPass;
 }
 
+QMap<int, FormatterLine *> XmlFormatter::silentFormat(const QString &data)
+{
+    QString currentFullTag = "";
+    QMap<int, FormatterLine*> result;
+    m_stackSize = 0;
+    bool tagStarted = false;
+    bool contentStarted = false;
+    m_formatterLine = new FormatterLine();
+    result[0] = m_formatterLine;
+
+    for(auto character: data) {
+        auto latinCharacter = character.toLatin1();
+
+        if (latinCharacter == m_tagStart && !tagStarted) {
+            tagStarted = true;
+            currentFullTag = latinCharacter;
+            if (contentStarted) {
+                contentStarted = false;
+                m_formatterLine = new FormatterLine(m_stackSize);
+                result[result.size()] = m_formatterLine;
+            }
+            continue;
+        }
+
+        if (latinCharacter == m_tagEnd && tagStarted) {
+            tagStarted = false;
+            currentFullTag.append(character);
+            formatTagWithOffsetSilent(currentFullTag, result);
+            currentFullTag.clear();
+            continue;
+        }
+
+        if (!tagStarted && latinCharacter != m_newline && latinCharacter != m_caretBack && latinCharacter != m_space && latinCharacter != m_tabulator) {
+            if (!contentStarted) {
+                contentStarted = true;
+            }
+            //m_result.append(character);
+            m_formatterLine->increaseLineIterator(character);
+        }
+        if (latinCharacter == m_space && contentStarted) {
+            //m_result.append(m_space);
+            m_formatterLine->increaseLineIterator(m_space[0]);
+        }
+        if (tagStarted && latinCharacter != m_newline) currentFullTag.append(character);
+    }
+
+    //remove last redundant item
+    if (!result.isEmpty()) {
+        auto lastItem = result.value(result.size() - 1);
+        if (lastItem->isEmpty()) result.remove(result.size() - 1);
+    }
+
+    return result;
+}
+
 void XmlFormatter::formatTagWithOffset(QString &tag)
 {
     auto closedTag = tag[1] == m_closedTag;
@@ -97,6 +149,60 @@ void XmlFormatter::formatTagWithOffset(QString &tag)
         setOffset();
         formatTag(tag);
         m_stackSize += 1;
+    }
+}
+
+void XmlFormatter::formatTagWithOffsetSilent(QString &tag, QMap<int, FormatterLine *> &result)
+{
+    auto closedTag = tag[1] == m_closedTag;
+    auto selfClosedTag = tag[tag.length() - 2] == m_closedTag;
+    auto header = tag[1] == m_question;
+    auto comment = tag.startsWith(m_comment);
+
+    if (header) {
+        m_formatterLine->increaseLineIterator('<');
+        m_formatterLine->addIndex("<font color=\"gray\">&lt;", false, true);
+        m_formatterLine->increaseLineIteratorString(tag.replace(">", "").replace("<", ""));
+        m_formatterLine->increaseLineIterator('>');
+        m_formatterLine->addIndex("&gt;</font>", false, true);
+
+        m_formatterLine = new FormatterLine(m_stackSize);
+        result[result.size()] = m_formatterLine;
+        return;
+    }
+
+    if (comment) {
+        m_formatterLine->increaseLineIterator('<');
+        m_formatterLine->addIndex("<font color=\"#008000\">&lt;", false, true);
+        m_formatterLine->increaseLineIteratorString(tag.replace(">", "").replace("<", ""));
+        m_formatterLine->increaseLineIterator('>');
+        m_formatterLine->addIndex("&gt;</font>", false, true);
+
+        m_formatterLine = new FormatterLine(m_stackSize);
+        result[result.size()] = m_formatterLine;
+        return;
+    }
+
+    if (closedTag) {
+        if (!selfClosedTag) {
+            m_stackSize -= 1;
+            m_formatterLine->setOffset(m_stackSize);
+        }
+        formatTagSilent(tag);
+
+        m_formatterLine = new FormatterLine(m_stackSize);
+        result[result.size()] = m_formatterLine;
+    } else if (selfClosedTag) {
+        formatTagSilent(tag);
+
+        m_formatterLine = new FormatterLine(m_stackSize);
+        result[result.size()] = m_formatterLine;
+    } else {
+        formatTagSilent(tag);
+        m_stackSize += 1;
+
+        m_formatterLine = new FormatterLine(m_stackSize);
+        result[result.size()] = m_formatterLine;
     }
 }
 
@@ -176,6 +282,81 @@ void XmlFormatter::formatTag(QString &tag)
     }
 
     m_result.append("</font>\n");
+}
+
+void XmlFormatter::formatTagSilent(QString &tag)
+{
+    auto contentIndex = tag.indexOf(m_space);
+    // it means tag without attributes, and we can use shortcut
+    if (contentIndex == -1) {
+        //m_result.append("<font color=\"#8812a1\">" + tag.replace("<", "&lt;").replace(">", "&gt;") + "</font>\n");
+        m_formatterLine->increaseLineIterator('<');
+        m_formatterLine->addIndex("<font color=\"#8812a1\">&lt;", false, true);
+        m_formatterLine->increaseLineIteratorString(tag.replace(">", "").replace("<", ""));
+        m_formatterLine->increaseLineIterator('>');
+        m_formatterLine->addIndex("&gt;</font>", false, true);
+        return;
+    }
+
+    bool attributeStarted = false;
+    bool stringStarted = false;
+    bool tagNameStarted = true;
+    bool closedPartStarted = false;
+
+    m_formatterLine->increaseLineIterator('<');
+    m_formatterLine->addIndex("<font color=\"#8812a1\">&lt;", false, true);
+
+    foreach(auto character, tag) {
+        auto latinCharacter = character.toLatin1();
+
+        m_formatterLine->increaseLineIterator(latinCharacter);
+
+        if (latinCharacter == m_space && !stringStarted) {
+            if (attributeStarted) {
+                attributeStarted = false;
+                m_formatterLine->addIndex("</font>", true, false);
+            }
+            if (tagNameStarted) {
+                tagNameStarted = false;
+                m_formatterLine->addIndex("</font>", true, false);
+            }
+            m_result.append(" ");
+        }
+
+        if (latinCharacter == m_tagStart) {
+            m_formatterLine->addIndex("&lt;", false, true);
+            continue;
+        }
+
+        if (!closedPartStarted && !attributeStarted && (latinCharacter == m_tagEnd || latinCharacter == m_closedTag)) {
+            m_formatterLine->addIndex("</font><font color=\"#8812a1\">", true, false);
+            closedPartStarted = true;
+        }
+
+        if (latinCharacter == m_tagEnd) {
+            m_formatterLine->addIndex("&gt;", false, true);
+            continue;
+        }
+
+        if (latinCharacter == m_attributeDecorator) {
+            if (stringStarted) {
+                stringStarted = false;
+                m_formatterLine->addIndex("&quot;</font>", false, true);
+            } else {
+                stringStarted = true;
+                m_formatterLine->addIndex("<font color=\"#2222dd\">&quot;", false, true);
+            }
+            continue;
+        }
+
+        if (!attributeStarted) {
+            attributeStarted = true;
+            m_formatterLine->addIndex("<font color=\"#994500\">", true, false);
+        }
+    }
+
+    m_formatterLine->increaseLineIterator('>');
+    m_formatterLine->addIndex("&gt;</font>", false, true);
 }
 
 void XmlFormatter::setOffset(int tabSize) noexcept

--- a/src/Formatters/xmlformatter.h
+++ b/src/Formatters/xmlformatter.h
@@ -44,7 +44,7 @@ public:
     XmlFormatter();
 
     QString format(const QString& data) override;
-    QMap<int, FormatterLine*> silentFormat(const QString &data);
+    QMap<int, FormatterLine*> silentFormat(const QString &data) override;
     void formatTagWithOffset(QString& tag);
     void formatTagWithOffsetSilent(QString& tag, QMap<int, FormatterLine*>& result);
     void formatTag(QString& tag);

--- a/src/Formatters/xmlformatter.h
+++ b/src/Formatters/xmlformatter.h
@@ -16,7 +16,9 @@
 #ifndef XMLFORMATTER_H
 #define XMLFORMATTER_H
 
+#include <QMap>
 #include "outputformatter.h"
+#include "formatterline.h"
 
 class XmlFormatter : public OutputFormatter
 {
@@ -36,14 +38,19 @@ class XmlFormatter : public OutputFormatter
     QString m_comment { "<!--" };
     int m_stackSize { -1 };
     QString m_result { "" };
+    FormatterLine* m_formatterLine { nullptr };
 
 public:
     XmlFormatter();
 
     QString format(const QString& data) override;
+    QMap<int, FormatterLine*> silentFormat(const QString &data);
     void formatTagWithOffset(QString& tag);
+    void formatTagWithOffsetSilent(QString& tag, QMap<int, FormatterLine*>& result);
     void formatTag(QString& tag);
+    void formatTagSilent(QString& tag);
     void setOffset(int tabSize = 4) noexcept;
+
 };
 
 #endif // XMLFORMATTER_H

--- a/src/Formatters/xmlformatter.h
+++ b/src/Formatters/xmlformatter.h
@@ -45,6 +45,7 @@ public:
 
     QString format(const QString& data) override;
     QMap<int, FormatterLine*> silentFormat(const QString &data) override;
+    int silentFormatTab() override { return 4; }
     void formatTagWithOffset(QString& tag);
     void formatTagWithOffsetSilent(QString& tag, QMap<int, FormatterLine*>& result);
     void formatTag(QString& tag);

--- a/src/ListModels/httprequestslistmodel.cpp
+++ b/src/ListModels/httprequestslistmodel.cpp
@@ -125,6 +125,14 @@ HttpRequestModel *HttpRequestsListModel::getSelectedRequest() const noexcept
     return m_requests->value(m_selectedIndex);
 }
 
+void HttpRequestsListModel::fillFontMetrics(const QFontMetrics fontMetrics)
+{
+    foreach (auto request, *m_requests) {
+        auto result = request->resultModel();
+        result->bodyModel()->setFontMetrics(fontMetrics);
+    }
+}
+
 void HttpRequestsListModel::selectItem(const int newIndex) noexcept
 {
     if (newIndex < 0) return;

--- a/src/ListModels/httprequestslistmodel.h
+++ b/src/ListModels/httprequestslistmodel.h
@@ -55,6 +55,7 @@ public:
     QSharedPointer<QList<HttpRequestModel*>> getList() const noexcept;
 
     HttpRequestModel* getSelectedRequest() const noexcept;
+    void fillFontMetrics(const QFontMetrics fontMetrics);
 
     Q_INVOKABLE void selectItem(const int newIndex) noexcept;
     Q_INVOKABLE void selectItemById(const QUuid& id) noexcept;

--- a/src/ListModels/responsebodylistmodel.cpp
+++ b/src/ListModels/responsebodylistmodel.cpp
@@ -36,6 +36,9 @@ QVariant ResponseBodyListModel::data(const QModelIndex &index, int role) const
     if (!index.isValid()) return QVariant();
 
     auto currentIndex = index.row();
+
+    if (!m_silentLines.contains(currentIndex)) return QVariant();
+
     auto currentLine = m_silentLines.value(currentIndex);
 
     switch (role) {
@@ -311,7 +314,6 @@ void ResponseBodyListModel::selectLine(int currentIndex, int width, int height, 
     Q_UNUSED(width);
     Q_UNUSED(height);
     Q_UNUSED(x);
-    Q_UNUSED(y);
     Q_UNUSED(formatting);
 
     QString line = QString(m_lines.value(currentIndex));
@@ -341,6 +343,7 @@ void ResponseBodyListModel::selectLine(int currentIndex, int width, int height, 
     int characterWidth = 0;
     int currentLine = 0;
     int characterIterator = 0;
+
     foreach (auto character, line) {
         auto newCharacterWidth = m_fontMetrics.boundingRect(QString(character)).width();
 
@@ -361,7 +364,6 @@ void ResponseBodyListModel::selectLine(int currentIndex, int width, int height, 
         characterWidth += newCharacterWidth;
         characterIterator += 1;
     }
-
 }
 
 QString & ResponseBodyListModel::cleanLineFromTags(QString &line) noexcept

--- a/src/ListModels/responsebodylistmodel.cpp
+++ b/src/ListModels/responsebodylistmodel.cpp
@@ -28,7 +28,7 @@ int ResponseBodyListModel::rowCount(const QModelIndex &parent) const
 {
     if (parent.isValid()) return 0;
 
-    return  m_lines.size();
+    return  m_silentLines.size();
 }
 
 QVariant ResponseBodyListModel::data(const QModelIndex &index, int role) const
@@ -36,11 +36,11 @@ QVariant ResponseBodyListModel::data(const QModelIndex &index, int role) const
     if (!index.isValid()) return QVariant();
 
     auto currentIndex = index.row();
-    auto line = m_lines.at(currentIndex);
+    auto currentLine = m_silentLines.value(currentIndex);
 
     switch (role) {
         case CurrentLineRole: {
-            return QVariant(line);
+            return QVariant(currentLine->formattedLine(m_silentLinesTab));
         }
         case IndexRole: {
             return QVariant::fromValue(currentIndex);
@@ -118,12 +118,15 @@ void ResponseBodyListModel::setBody(const QByteArray &body, const QString& forma
 void ResponseBodyListModel::reformatting(const QString &formatter) noexcept
 {
     m_lines.clear();
+    m_silentLines.clear();
     auto body = getFullBody();
     auto isHasFormatter = !formatter.isEmpty();
     auto lines = body.split("\n");
     if (isHasFormatter) {
         auto formatterInstance = m_formatterFactory->getFormatter(formatter);
         lines = formatterInstance->format(body).split("\n");
+        m_silentLines = formatterInstance->silentFormat(body);
+        m_silentLinesTab = formatterInstance->silentFormatTab();
     }
     foreach (auto line, lines) {
         if (isHasFormatter || line.length() < 100) {

--- a/src/ListModels/responsebodylistmodel.cpp
+++ b/src/ListModels/responsebodylistmodel.cpp
@@ -45,7 +45,6 @@ QVariant ResponseBodyListModel::data(const QModelIndex &index, int role) const
         case CurrentLineRole: {
             auto isSameLine = m_startSelectedLine > -1 && m_startSelectedLine == m_endSelectedLine && currentIndex == m_startSelectedLine;
             if (isSameLine) {
-                qDebug() << "SAME LINE!!!";
                 if (m_startSelectedCharacter < m_endSelectedCharacter) {
                     qDebug() << currentLine->formattedLineWithSelection(m_silentLinesTab, m_startSelectedCharacter, m_endSelectedCharacter);
                     return QVariant(currentLine->formattedLineWithSelection(m_silentLinesTab, m_startSelectedCharacter, m_endSelectedCharacter));
@@ -345,6 +344,7 @@ void ResponseBodyListModel::selectLine(int currentIndex, int width, int height, 
 
     FormatterLine* silentLine = m_silentLines.value(currentIndex);
     silentLine->fillLineWithOffset(m_silentLinesTab);
+    qDebug() << "tab " << QString::number(m_silentLinesTab) << " " << QString::number(silentLine->offset());
 
     QString line = silentLine->lineWithOffset();
 
@@ -379,7 +379,7 @@ void ResponseBodyListModel::selectLine(int currentIndex, int width, int height, 
         characterIterator += 1;
     }
 
-    qDebug() << QString::number(m_startSelectedCharacter) << " - " << QString::number(m_endSelectedCharacter);
+    //qDebug() << QString::number(m_startSelectedCharacter) << " - " << QString::number(m_endSelectedCharacter);
     emit dataChanged(index(oldEndSelectedLine), index(oldEndSelectedLine));
     emit dataChanged(index(currentIndex), index(currentIndex));
 }

--- a/src/ListModels/responsebodylistmodel.cpp
+++ b/src/ListModels/responsebodylistmodel.cpp
@@ -121,8 +121,13 @@ void ResponseBodyListModel::setBody(const QByteArray &body, const QString& forma
 void ResponseBodyListModel::reformatting(const QString &formatter) noexcept
 {
     m_lines.clear();
-    foreach(auto silentLine, m_silentLines) delete silentLine;
+    for(auto i = 0; i < m_silentLines.size(); i++) {
+        auto silentLine = m_silentLines.value(i);
+        delete silentLine;
+        m_silentLines[i] = nullptr;
+    }
     m_silentLines.clear();
+    m_silentLinesTab = 0;
     auto body = getFullBody();
     auto isHasFormatter = !formatter.isEmpty();
     auto lines = body.split("\n");

--- a/src/ListModels/responsebodylistmodel.cpp
+++ b/src/ListModels/responsebodylistmodel.cpp
@@ -121,6 +121,7 @@ void ResponseBodyListModel::setBody(const QByteArray &body, const QString& forma
 void ResponseBodyListModel::reformatting(const QString &formatter) noexcept
 {
     m_lines.clear();
+    foreach(auto silentLine, m_silentLines) delete silentLine;
     m_silentLines.clear();
     auto body = getFullBody();
     auto isHasFormatter = !formatter.isEmpty();

--- a/src/ListModels/responsebodylistmodel.cpp
+++ b/src/ListModels/responsebodylistmodel.cpp
@@ -46,7 +46,6 @@ QVariant ResponseBodyListModel::data(const QModelIndex &index, int role) const
             auto isSameLine = m_startSelectedLine > -1 && m_startSelectedLine == m_endSelectedLine && currentIndex == m_startSelectedLine;
             if (isSameLine) {
                 if (m_startSelectedCharacter < m_endSelectedCharacter) {
-                    qDebug() << currentLine->formattedLineWithSelection(m_silentLinesTab, m_startSelectedCharacter, m_endSelectedCharacter);
                     return QVariant(currentLine->formattedLineWithSelection(m_silentLinesTab, m_startSelectedCharacter, m_endSelectedCharacter));
                 } else {
                     return QVariant(currentLine->formattedLineWithSelection(m_silentLinesTab, m_endSelectedCharacter, m_startSelectedCharacter));
@@ -344,7 +343,6 @@ void ResponseBodyListModel::selectLine(int currentIndex, int width, int height, 
 
     FormatterLine* silentLine = m_silentLines.value(currentIndex);
     silentLine->fillLineWithOffset(m_silentLinesTab);
-    qDebug() << "tab " << QString::number(m_silentLinesTab) << " " << QString::number(silentLine->offset());
 
     QString line = silentLine->lineWithOffset();
 
@@ -355,8 +353,9 @@ void ResponseBodyListModel::selectLine(int currentIndex, int width, int height, 
     int characterIterator = 0;
 
     foreach (auto character, line) {
-        auto newCharacterWidth = m_defaultCharacterWidth;
-        qDebug() << QString::number(characterIterator);
+        auto newCharacterWidth = m_fontMetrics.boundingRect(character).width();
+        if (character == ' ') newCharacterWidth = m_defaultCharacterWidth;
+
         if (m_shortCharacters.contains(character)) {
             newCharacterWidth = m_shortCharacterWidth;
         }
@@ -379,7 +378,7 @@ void ResponseBodyListModel::selectLine(int currentIndex, int width, int height, 
         characterIterator += 1;
     }
 
-    //qDebug() << QString::number(m_startSelectedCharacter) << " - " << QString::number(m_endSelectedCharacter);
+    qDebug() << QString::number(m_startSelectedCharacter) << " - " << QString::number(m_endSelectedCharacter);
     emit dataChanged(index(oldEndSelectedLine), index(oldEndSelectedLine));
     emit dataChanged(index(currentIndex), index(currentIndex));
 }

--- a/src/ListModels/responsebodylistmodel.h
+++ b/src/ListModels/responsebodylistmodel.h
@@ -40,6 +40,8 @@ class ResponseBodyListModel : public QAbstractListModel
 
 private:
     QStringList m_lines { QStringList() };
+    QMap<int, FormatterLine *> m_silentLines { QMap<int, FormatterLine *>() };
+    int m_silentLinesTab { 0 };
     QByteArray m_originalBody { "" };
     QList<std::tuple<int, int>> m_findedLines { QList<std::tuple<int, int>>() };
     QMap<int, int> m_findedLinesMap { QMap<int, int>() };

--- a/src/ListModels/responsebodylistmodel.h
+++ b/src/ListModels/responsebodylistmodel.h
@@ -59,6 +59,9 @@ private:
     int m_startSelectedCharacter { -1 };
     int m_endSelectedCharacter { -1 };
     int m_fontHeight { 0 };
+    int m_defaultCharacterWidth { 0 };
+    int m_shortCharacterWidth { 0 };
+    const QString m_shortCharacters { "iIjl" };
     QFontMetrics m_fontMetrics { QFontMetrics(QFont()) };
 
     enum ResponseBodyRoles {

--- a/src/ListModels/responsebodylistmodel.h
+++ b/src/ListModels/responsebodylistmodel.h
@@ -22,6 +22,8 @@
 #include <QMap>
 #include <QList>
 #include <QRegularExpression>
+#include <QFont>
+#include <QFontMetrics>
 #include "../Formatters/formatterfactory.h"
 #include "../globalconstants.h"
 
@@ -33,6 +35,8 @@ class ResponseBodyListModel : public QAbstractListModel
     Q_PROPERTY(int bodyImageHeight READ bodyImageHeight NOTIFY bodyImageHeightChanged)
     Q_PROPERTY(int countFindedLines READ countFindedLines NOTIFY countFindedLinesChanged)
     Q_PROPERTY(QString countFindedLinesText READ countFindedLinesText NOTIFY countFindedLinesTextChanged)
+    Q_PROPERTY(bool lineStarted READ lineStarted NOTIFY lineStartedChanged FINAL)
+    Q_PROPERTY(QFontMetrics fontMetrics READ fontMetrics WRITE setFontMetrics NOTIFY fontMetricsChanged FINAL)
 
 private:
     QStringList m_lines { QStringList() };
@@ -48,11 +52,18 @@ private:
     QString m_previousFilter { "" };
     int m_typingTimerId { -1 };
     QString m_typingFilter { "" };
+    int m_startSelectedLine { -1 };
+    int m_endSelectedLine { -1 };
+    int m_startSelectedCharacter { -1 };
+    int m_endSelectedCharacter { -1 };
+    int m_fontHeight { 0 };
+    QFontMetrics m_fontMetrics { QFontMetrics(QFont()) };
 
     enum ResponseBodyRoles {
         CurrentLineRole = Qt::UserRole + 1,
         IndexRole,
-        IsFindIndexRole
+        IsFindIndexRole,
+        IsSelectedLineRole,
     };
 
 public:
@@ -73,16 +84,23 @@ public:
     int bodyImageHeight() const noexcept { return m_imageSource.height(); }
     int countFindedLines() const noexcept { return m_findedLines.count(); }
     QString countFindedLinesText() const noexcept;
+    bool lineStarted() const noexcept { return m_startSelectedLine > -1; }
     int nextFindedResult() noexcept;
     int previousFindedResult() noexcept;
     int getCurrentFindedLine() noexcept;
     void clear() noexcept;
 
+    QFontMetrics fontMetrics() const noexcept { return m_fontMetrics; }
+    void setFontMetrics(const QFontMetrics& fontMetrics) noexcept;
+
     Q_INVOKABLE void searchText(const QString& filter) noexcept;
     Q_INVOKABLE void startSearchText(const QString& filter) noexcept;
+    Q_INVOKABLE void selectStartLine(int currentIndex) noexcept;
+    Q_INVOKABLE void selectLine(int currentIndex, int width, int height, int x, int y, bool formatting) noexcept;
 
 private:
     QString& cleanLineFromTags(QString& line) noexcept;
+    void clearCurrentSelection() noexcept;
 
 protected:
     void timerEvent(QTimerEvent *event) override;
@@ -94,6 +112,8 @@ signals:
     void bodyImageHeightChanged();
     void countFindedLinesChanged();
     void countFindedLinesTextChanged();
+    void lineStartedChanged();
+    void fontMetricsChanged();
 
 };
 

--- a/src/Tests/cssformatterunittests.cpp
+++ b/src/Tests/cssformatterunittests.cpp
@@ -119,6 +119,20 @@ void CssFormatterUnitTests::nestedstyles_completed()
     QCOMPARE(result, expectedResult);
 }
 
+void CssFormatterUnitTests::nestedstyles_silent_completed()
+{
+    CssFormatter formatter;
+    auto result = formatter.silentFormat(".myclass {property: value; .nestedclass { nestedproperty: nestedvalue; } }");
+
+    QCOMPARE(result.size(), 6);
+    QCOMPARE(result.value(0)->formattedLine(4), R"(<font color="#8812a1">.myclass </font>{)");
+    QCOMPARE(result.value(1)->formattedLine(4), R"(&nbsp;&nbsp;&nbsp;&nbsp;<font color="#009dd5">property</font>: value;)");
+    QCOMPARE(result.value(2)->formattedLine(4), R"(&nbsp;&nbsp;&nbsp;&nbsp;<font color="#8812a1">.nestedclass </font>{)");
+    QCOMPARE(result.value(3)->formattedLine(4), R"(&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<font color="#009dd5">nestedproperty</font>: nestedvalue;)");
+    QCOMPARE(result.value(4)->formattedLine(4), R"(&nbsp;&nbsp;&nbsp;&nbsp;})");
+    QCOMPARE(result.value(5)->formattedLine(4), R"(})");
+}
+
 void CssFormatterUnitTests::comment_beforeStyle()
 {
     CssFormatter formatter;
@@ -133,6 +147,20 @@ void CssFormatterUnitTests::comment_beforeStyle()
     QCOMPARE(result, expectedResult);
 }
 
+void CssFormatterUnitTests::comment_silent_beforeStyle()
+{
+    CssFormatter formatter;
+    auto result = formatter.silentFormat("/* This is the comment!!!! */.myclass {property: value; .nestedclass { nestedproperty: nestedvalue; } }");
+
+    QCOMPARE(result.size(), 6);
+    QCOMPARE(result.value(0)->formattedLine(4), R"(<font color="#8812a1"><font color="#008000">/* This is the comment!!!! */</font>.myclass </font>{)");
+    QCOMPARE(result.value(1)->formattedLine(4), R"(&nbsp;&nbsp;&nbsp;&nbsp;<font color="#009dd5">property</font>: value;)");
+    QCOMPARE(result.value(2)->formattedLine(4), R"(&nbsp;&nbsp;&nbsp;&nbsp;<font color="#8812a1">.nestedclass </font>{)");
+    QCOMPARE(result.value(3)->formattedLine(4), R"(&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<font color="#009dd5">nestedproperty</font>: nestedvalue;)");
+    QCOMPARE(result.value(4)->formattedLine(4), R"(&nbsp;&nbsp;&nbsp;&nbsp;})");
+    QCOMPARE(result.value(5)->formattedLine(4), R"(})");
+}
+
 void CssFormatterUnitTests::comment_insideProperty()
 {
     CssFormatter formatter;
@@ -142,6 +170,17 @@ void CssFormatterUnitTests::comment_insideProperty()
 }
 )a");
     QCOMPARE(result, expectedResult);
+}
+
+void CssFormatterUnitTests::comment_insideProperty_silent_completed()
+{
+    CssFormatter formatter;
+    auto result = formatter.silentFormat(".myclass {property: value /* This is the comment!!!! */; }");
+
+    QCOMPARE(result.size(), 3);
+    QCOMPARE(result.value(0)->formattedLine(4), R"(<font color="#8812a1">.myclass </font>{)");
+    QCOMPARE(result.value(1)->formattedLine(4), R"(&nbsp;&nbsp;&nbsp;&nbsp;<font color="#009dd5">property</font>: value<font color="#008000">/* This is the comment!!!! */</font>;)");
+    QCOMPARE(result.value(2)->formattedLine(4), R"(})");
 }
 
 void CssFormatterUnitTests::simplestyle_singlePropertyWithoutSemicolon()
@@ -155,6 +194,17 @@ void CssFormatterUnitTests::simplestyle_singlePropertyWithoutSemicolon()
     QCOMPARE(result, expectedResult);
 }
 
+void CssFormatterUnitTests::simplestyle_singlePropertyWithoutSemicolon_silent_completed()
+{
+    CssFormatter formatter;
+    auto result = formatter.silentFormat(".myclass {property: value }");
+
+    QCOMPARE(result.size(), 3);
+    QCOMPARE(result.value(0)->formattedLine(4), R"(<font color="#8812a1">.myclass </font>{)");
+    QCOMPARE(result.value(1)->formattedLine(4), R"(&nbsp;&nbsp;&nbsp;&nbsp;<font color="#009dd5">property</font>: value;)");
+    QCOMPARE(result.value(2)->formattedLine(4), R"(})");
+}
+
 void CssFormatterUnitTests::simplestyle_multiplePropertyLastWithoutSemicolon()
 {
     CssFormatter formatter;
@@ -165,4 +215,16 @@ void CssFormatterUnitTests::simplestyle_multiplePropertyLastWithoutSemicolon()
 }
 )a");
     QCOMPARE(result, expectedResult);
+}
+
+void CssFormatterUnitTests::simplestyle_multiplePropertyLastWithoutSemicolon_silent_completed()
+{
+    CssFormatter formatter;
+    auto result = formatter.silentFormat(".myclass {property: value; property2: value2 }");
+
+    QCOMPARE(result.size(), 4);
+    QCOMPARE(result.value(0)->formattedLine(4), R"(<font color="#8812a1">.myclass </font>{)");
+    QCOMPARE(result.value(1)->formattedLine(4), R"(&nbsp;&nbsp;&nbsp;&nbsp;<font color="#009dd5">property</font>: value;)");
+    QCOMPARE(result.value(2)->formattedLine(4), R"(&nbsp;&nbsp;&nbsp;&nbsp;<font color="#009dd5">property2</font>: value2;)");
+    QCOMPARE(result.value(3)->formattedLine(4), R"(})");
 }

--- a/src/Tests/cssformatterunittests.cpp
+++ b/src/Tests/cssformatterunittests.cpp
@@ -34,6 +34,17 @@ void CssFormatterUnitTests::simplestyle_completed()
     QCOMPARE(result, expectedResult);
 }
 
+void CssFormatterUnitTests::simplestyle_completedSilent()
+{
+    CssFormatter formatter;
+    auto result = formatter.silentFormat(".myclass {property: value;}");
+
+    QCOMPARE(result.size(), 3);
+    QCOMPARE(result.value(0)->formattedLine(4), R"(<font color="#8812a1">.myclass </font>{)");
+    QCOMPARE(result.value(1)->formattedLine(4), R"(&nbsp;&nbsp;&nbsp;&nbsp;<font color="#009dd5">property</font>: value;)");
+    QCOMPARE(result.value(2)->formattedLine(4), R"(})");
+}
+
 void CssFormatterUnitTests::simplestyle_multiplevalues_completed()
 {
     CssFormatter formatter;
@@ -45,6 +56,19 @@ void CssFormatterUnitTests::simplestyle_multiplevalues_completed()
 }
 )a");
     QCOMPARE(result, expectedResult);
+}
+
+void CssFormatterUnitTests::simplestyle_multiplevalues_completedSilent()
+{
+    CssFormatter formatter;
+    auto result = formatter.silentFormat(".myclass {property: value; property2: lalala ; purupu  : vallll    ;}");
+
+    QCOMPARE(result.size(), 5);
+    QCOMPARE(result.value(0)->formattedLine(4), R"(<font color="#8812a1">.myclass </font>{)");
+    QCOMPARE(result.value(1)->formattedLine(4), R"(&nbsp;&nbsp;&nbsp;&nbsp;<font color="#009dd5">property</font>: value;)");
+    QCOMPARE(result.value(2)->formattedLine(4), R"(&nbsp;&nbsp;&nbsp;&nbsp;<font color="#009dd5">property2</font>: lalala;)");
+    QCOMPARE(result.value(3)->formattedLine(4), R"(&nbsp;&nbsp;&nbsp;&nbsp;<font color="#009dd5">purupu</font>: vallll;)");
+    QCOMPARE(result.value(4)->formattedLine(4), R"(})");
 }
 
 void CssFormatterUnitTests::multiplestyles_multiplevalues_completed()
@@ -62,6 +86,23 @@ void CssFormatterUnitTests::multiplestyles_multiplevalues_completed()
 }
 )a");
     QCOMPARE(result, expectedResult);
+}
+
+void CssFormatterUnitTests::multiplestyles_multiplevalues_completedSilent()
+{
+    CssFormatter formatter;
+    auto result = formatter.silentFormat(".myclass {property: value; property2: lalala ; purupu  : vallll;}   .myclass2 { muhers: pruher; muhers2: pruher2; }");
+
+    QCOMPARE(result.size(), 9);
+    QCOMPARE(result.value(0)->formattedLine(4), R"(<font color="#8812a1">.myclass </font>{)");
+    QCOMPARE(result.value(1)->formattedLine(4), R"(&nbsp;&nbsp;&nbsp;&nbsp;<font color="#009dd5">property</font>: value;)");
+    QCOMPARE(result.value(2)->formattedLine(4), R"(&nbsp;&nbsp;&nbsp;&nbsp;<font color="#009dd5">property2</font>: lalala;)");
+    QCOMPARE(result.value(3)->formattedLine(4), R"(&nbsp;&nbsp;&nbsp;&nbsp;<font color="#009dd5">purupu</font>: vallll;)");
+    QCOMPARE(result.value(4)->formattedLine(4), R"(})");
+    QCOMPARE(result.value(5)->formattedLine(4), R"(<font color="#8812a1">.myclass2 </font>{)");
+    QCOMPARE(result.value(6)->formattedLine(4), R"(&nbsp;&nbsp;&nbsp;&nbsp;<font color="#009dd5">muhers</font>: pruher;)");
+    QCOMPARE(result.value(7)->formattedLine(4), R"(&nbsp;&nbsp;&nbsp;&nbsp;<font color="#009dd5">muhers2</font>: pruher2;)");
+    QCOMPARE(result.value(8)->formattedLine(4), R"(})");
 }
 
 void CssFormatterUnitTests::nestedstyles_completed()

--- a/src/Tests/cssformatterunittests.h
+++ b/src/Tests/cssformatterunittests.h
@@ -32,10 +32,15 @@ private slots:
     void multiplestyles_multiplevalues_completed();
     void multiplestyles_multiplevalues_completedSilent();
     void nestedstyles_completed();
+    void nestedstyles_silent_completed();
     void comment_beforeStyle();
+    void comment_silent_beforeStyle();
     void comment_insideProperty();
+    void comment_insideProperty_silent_completed();
     void simplestyle_singlePropertyWithoutSemicolon();
+    void simplestyle_singlePropertyWithoutSemicolon_silent_completed();
     void simplestyle_multiplePropertyLastWithoutSemicolon();
+    void simplestyle_multiplePropertyLastWithoutSemicolon_silent_completed();
 
 };
 

--- a/src/Tests/cssformatterunittests.h
+++ b/src/Tests/cssformatterunittests.h
@@ -26,8 +26,11 @@ public:
 
 private slots:
     void simplestyle_completed();
+    void simplestyle_completedSilent();
     void simplestyle_multiplevalues_completed();
+    void simplestyle_multiplevalues_completedSilent();
     void multiplestyles_multiplevalues_completed();
+    void multiplestyles_multiplevalues_completedSilent();
     void nestedstyles_completed();
     void comment_beforeStyle();
     void comment_insideProperty();

--- a/src/Tests/htmlformatterunittests.cpp
+++ b/src/Tests/htmlformatterunittests.cpp
@@ -31,6 +31,15 @@ void HtmlFormatterUnitTests::htmlLowerHeader()
     QCOMPARE(result, expectedResult);
 }
 
+void HtmlFormatterUnitTests::htmlLowerHeaderSilent()
+{
+    HtmlFormatter formatter;
+    auto result = formatter.silentFormat("<!doctype html>");
+
+    QCOMPARE(result.size(), 1);
+    QCOMPARE(result.value(0)->formattedLine(1), R"(<font color="lightgray">&lt;!doctype html&gt;</font>)");
+}
+
 void HtmlFormatterUnitTests::htmlUpperHeader()
 {
     HtmlFormatter formatter;
@@ -38,6 +47,15 @@ void HtmlFormatterUnitTests::htmlUpperHeader()
     auto expectedResult = QString(R"a(<font color="lightgray">&lt;!DOCTYPE html&gt;</font>
 )a");
     QCOMPARE(result, expectedResult);
+}
+
+void HtmlFormatterUnitTests::htmlUpperHeaderSilent()
+{
+    HtmlFormatter formatter;
+    auto result = formatter.silentFormat("<!DOCTYPE html>");
+
+    QCOMPARE(result.size(), 1);
+    QCOMPARE(result.value(0)->formattedLine(1), R"(<font color="lightgray">&lt;!DOCTYPE html&gt;</font>)");
 }
 
 void HtmlFormatterUnitTests::emptyFullTag()
@@ -50,6 +68,16 @@ void HtmlFormatterUnitTests::emptyFullTag()
     QCOMPARE(result, expectedResult);
 }
 
+void HtmlFormatterUnitTests::emptyFullTagSilent()
+{
+    HtmlFormatter formatter;
+    auto result = formatter.silentFormat("<test></test>");
+
+    QCOMPARE(result.size(), 2);
+    QCOMPARE(result.value(0)->formattedLine(1), R"(<font color="#8812a1">&lt;test&gt;</font>)");
+    QCOMPARE(result.value(1)->formattedLine(1), R"(<font color="#8812a1">&lt;/test&gt;</font>)");
+}
+
 void HtmlFormatterUnitTests::attributeWithUrl()
 {
     HtmlFormatter formatter;
@@ -58,6 +86,16 @@ void HtmlFormatterUnitTests::attributeWithUrl()
 <font color="#8812a1">&lt;/test&gt;</font>
 )");
     QCOMPARE(result, expectedResult);
+}
+
+void HtmlFormatterUnitTests::attributeWithUrlSilent()
+{
+    HtmlFormatter formatter;
+    auto result = formatter.silentFormat(R"(<test attr="http://www.test.com"></test>)");
+
+    QCOMPARE(result.size(), 2);
+    QCOMPARE(result.value(0)->formattedLine(1), R"(<font color="#8812a1">&lt;test</font> <font color="#994500">attr=<font color="#2222dd">&quot;http://www.test.com&quot;</font>&gt;</font>)");
+    QCOMPARE(result.value(1)->formattedLine(1), R"(<font color="#8812a1">&lt;/test&gt;</font>)");
 }
 
 void HtmlFormatterUnitTests::commentTag()
@@ -69,4 +107,22 @@ void HtmlFormatterUnitTests::commentTag()
 <font color="#8812a1">&lt;/test&gt;</font>
 )");
     QCOMPARE(result, expectedResult);
+}
+
+void HtmlFormatterUnitTests::commentTagSilent()
+{
+    HtmlFormatter formatter;
+    auto result = formatter.silentFormat(R"(<test><!-- comment --></test>)");
+
+    QCOMPARE(result.size(), 3);
+    QCOMPARE(result.value(0)->formattedLine(1), R"(<font color="#8812a1">&lt;test&gt;</font>)");
+    qDebug() << R"(<font color="#008000">&lt;!-- comment --&gt;</font>)";
+    qDebug() << result.value(1)->formattedLine(1);
+    QCOMPARE(result.value(1)->formattedLine(1), R"(<font color="#008000">&lt;!-- comment --&gt;</font>)");
+    QCOMPARE(result.value(2)->formattedLine(1), R"(<font color="#8812a1">&lt;/test&gt;</font>)");
+
+    QCOMPARE(result.value(0)->line(), R"(<test>)");
+    QCOMPARE(result.value(1)->line(), R"(<!-- comment -->)");
+    QCOMPARE(result.value(2)->line(), R"(</test>)");
+
 }

--- a/src/Tests/htmlformatterunittests.cpp
+++ b/src/Tests/htmlformatterunittests.cpp
@@ -137,3 +137,33 @@ void HtmlFormatterUnitTests::innerContentNewLine()
     QCOMPARE(result.value(3)->formattedLine(1), R"(&nbsp;<font color="#8812a1">&lt;/test&gt;</font>)");
     QCOMPARE(result.value(4)->formattedLine(1), R"(<font color="#8812a1">&lt;/upper&gt;</font>)");
 }
+
+void HtmlFormatterUnitTests::formattedLineWithSelection_case1()
+{
+    HtmlFormatter formatter;
+    auto result = formatter.silentFormat("<head>");
+
+    QCOMPARE(result.size(), 1);
+    auto firstLine = result.value(0);
+    QCOMPARE(firstLine->formattedLineWithSelection(0, 0, -1), "<span style=\"background-color: #788a8a5c; color: white;\"><font >&lt;head&gt;</font></span>");
+}
+
+void HtmlFormatterUnitTests::formattedLineWithSelection_case2()
+{
+    HtmlFormatter formatter;
+    auto result = formatter.silentFormat("<head>");
+
+    QCOMPARE(result.size(), 1);
+    auto firstLine = result.value(0);
+    QCOMPARE(firstLine->formattedLineWithSelection(0, 0, 2), "<span style=\"background-color: #788a8a5c; color: white;\"><font >&lt;he</span>ad&gt;</font>");
+}
+
+void HtmlFormatterUnitTests::formattedLineWithSelection_case3()
+{
+    HtmlFormatter formatter;
+    auto result = formatter.silentFormat("<head>");
+
+    QCOMPARE(result.size(), 1);
+    auto firstLine = result.value(0);
+    QCOMPARE(firstLine->formattedLineWithSelection(0, 2, 4), "<font color=\"#8812a1\">&lt;h<span style=\"background-color: #788a8a5c; color: white;\">ead</span>&gt;</font>");
+}

--- a/src/Tests/htmlformatterunittests.cpp
+++ b/src/Tests/htmlformatterunittests.cpp
@@ -167,3 +167,30 @@ void HtmlFormatterUnitTests::formattedLineWithSelection_case3()
     auto firstLine = result.value(0);
     QCOMPARE(firstLine->formattedLineWithSelection(0, 2, 4), "<font color=\"#8812a1\">&lt;h<span style=\"background-color: #788a8a5c; color: white;\">ead</span>&gt;</font>");
 }
+
+void HtmlFormatterUnitTests::formattedLineWithSelection_case4()
+{
+    HtmlFormatter formatter;
+    auto result = formatter.silentFormat(R"(<link rel="dns-prefetch href="https://github.com/blaballba">)");
+
+    QCOMPARE(result.size(), 1);
+    auto firstLine = result.value(0);
+    QCOMPARE(
+        firstLine->formattedLineWithSelection(0, 18, 14),
+        "<font color=\"#8812a1\">&lt;link</font><font color=\"#994500\"> rel=<font color=\"#2222dd\">&quot;dns<span style=\"background-color: #788a8a5c; color: white;\">-pref</span>etch href=&quot;</font>https://github.com/blaballba<font color=\"#2222dd\">&quot;&gt;</font>"
+    );
+}
+
+void HtmlFormatterUnitTests::formattedLineWithSelection_case5()
+{
+    HtmlFormatter formatter;
+    auto result = formatter.silentFormat(R"(<link rel="dns-prefetch href="https://github.com/blaballba">)");
+
+    QCOMPARE(result.size(), 1);
+    auto firstLine = result.value(0);
+    qDebug() << firstLine->formattedLineWithSelection(0, 14, 29);
+    QCOMPARE(
+        firstLine->formattedLineWithSelection(0, 14, 29),
+        "<font color=\"#8812a1\">&lt;link</font><font color=\"#994500\"> rel=<font color=\"#2222dd\">&quot;dns<span style=\"background-color: #788a8a5c; color: white;\">-prefetch href=&quot;</font></span>https://github.com/blaballba<font color=\"#2222dd\">&quot;&gt;</font>"
+    );
+}

--- a/src/Tests/htmlformatterunittests.cpp
+++ b/src/Tests/htmlformatterunittests.cpp
@@ -116,13 +116,24 @@ void HtmlFormatterUnitTests::commentTagSilent()
 
     QCOMPARE(result.size(), 3);
     QCOMPARE(result.value(0)->formattedLine(1), R"(<font color="#8812a1">&lt;test&gt;</font>)");
-    qDebug() << R"(<font color="#008000">&lt;!-- comment --&gt;</font>)";
-    qDebug() << result.value(1)->formattedLine(1);
-    QCOMPARE(result.value(1)->formattedLine(1), R"(<font color="#008000">&lt;!-- comment --&gt;</font>)");
+    QCOMPARE(result.value(1)->formattedLine(1), R"(&nbsp;<font color="#008000">&lt;!-- comment --&gt;</font>)");
     QCOMPARE(result.value(2)->formattedLine(1), R"(<font color="#8812a1">&lt;/test&gt;</font>)");
 
     QCOMPARE(result.value(0)->line(), R"(<test>)");
     QCOMPARE(result.value(1)->line(), R"(<!-- comment -->)");
     QCOMPARE(result.value(2)->line(), R"(</test>)");
 
+}
+
+void HtmlFormatterUnitTests::innerContentNewLine()
+{
+    HtmlFormatter formatter;
+    auto result = formatter.silentFormat("<upper><test>luper</test></upper>");
+
+    QCOMPARE(result.size(), 5);
+    QCOMPARE(result.value(0)->formattedLine(1), R"(<font color="#8812a1">&lt;upper&gt;</font>)");
+    QCOMPARE(result.value(1)->formattedLine(1), R"(&nbsp;<font color="#8812a1">&lt;test&gt;</font>)");
+    QCOMPARE(result.value(2)->formattedLine(1), R"(&nbsp;&nbsp;luper)");
+    QCOMPARE(result.value(3)->formattedLine(1), R"(&nbsp;<font color="#8812a1">&lt;/test&gt;</font>)");
+    QCOMPARE(result.value(4)->formattedLine(1), R"(<font color="#8812a1">&lt;/upper&gt;</font>)");
 }

--- a/src/Tests/htmlformatterunittests.cpp
+++ b/src/Tests/htmlformatterunittests.cpp
@@ -94,7 +94,7 @@ void HtmlFormatterUnitTests::attributeWithUrlSilent()
     auto result = formatter.silentFormat(R"(<test attr="http://www.test.com"></test>)");
 
     QCOMPARE(result.size(), 2);
-    QCOMPARE(result.value(0)->formattedLine(1), R"(<font color="#8812a1">&lt;test</font> <font color="#994500">attr=<font color="#2222dd">&quot;http://www.test.com&quot;</font>&gt;</font>)");
+    QCOMPARE(result.value(0)->formattedLine(1), R"(<font color="#8812a1">&lt;test</font><font color="#994500"> attr=<font color="#2222dd">&quot;http://www.test.com&quot;</font>&gt;</font>)");
     QCOMPARE(result.value(1)->formattedLine(1), R"(<font color="#8812a1">&lt;/test&gt;</font>)");
 }
 

--- a/src/Tests/htmlformatterunittests.cpp
+++ b/src/Tests/htmlformatterunittests.cpp
@@ -145,7 +145,7 @@ void HtmlFormatterUnitTests::formattedLineWithSelection_case1()
 
     QCOMPARE(result.size(), 1);
     auto firstLine = result.value(0);
-    QCOMPARE(firstLine->formattedLineWithSelection(0, 0, -1), "<span style=\"background-color: #788a8a5c; color: white;\"><font >&lt;head&gt;</font></span>");
+    QCOMPARE(firstLine->formattedLineWithSelection(0, 0, -1), "<span style=\"background-color: #788a8a5c; color: white;\">&lt;head&gt;</span>");
 }
 
 void HtmlFormatterUnitTests::formattedLineWithSelection_case2()
@@ -155,7 +155,7 @@ void HtmlFormatterUnitTests::formattedLineWithSelection_case2()
 
     QCOMPARE(result.size(), 1);
     auto firstLine = result.value(0);
-    QCOMPARE(firstLine->formattedLineWithSelection(0, 0, 2), "<span style=\"background-color: #788a8a5c; color: white;\"><font >&lt;he</span>ad&gt;</font>");
+    QCOMPARE(firstLine->formattedLineWithSelection(0, 0, 2), "<span style=\"background-color: #788a8a5c; color: white;\">&lt;he</span>ad&gt;</font>");
 }
 
 void HtmlFormatterUnitTests::formattedLineWithSelection_case3()
@@ -191,6 +191,6 @@ void HtmlFormatterUnitTests::formattedLineWithSelection_case5()
     qDebug() << firstLine->formattedLineWithSelection(0, 14, 29);
     QCOMPARE(
         firstLine->formattedLineWithSelection(0, 14, 29),
-        "<font color=\"#8812a1\">&lt;link</font><font color=\"#994500\"> rel=<font color=\"#2222dd\">&quot;dns<span style=\"background-color: #788a8a5c; color: white;\">-prefetch href=&quot;</font></span>https://github.com/blaballba<font color=\"#2222dd\">&quot;&gt;</font>"
+        "<font color=\"#8812a1\">&lt;link</font><font color=\"#994500\"> rel=<font color=\"#2222dd\">&quot;dns<span style=\"background-color: #788a8a5c; color: white;\">-prefetch href=&quot;</span>https://github.com/blaballba<font color=\"#2222dd\">&quot;&gt;</font>"
     );
 }

--- a/src/Tests/htmlformatterunittests.h
+++ b/src/Tests/htmlformatterunittests.h
@@ -40,6 +40,8 @@ private slots:
     void formattedLineWithSelection_case1();
     void formattedLineWithSelection_case2();
     void formattedLineWithSelection_case3();
+    void formattedLineWithSelection_case4();
+    void formattedLineWithSelection_case5();
 };
 
 #endif // HTMLFORMATTERUNITTESTS_H

--- a/src/Tests/htmlformatterunittests.h
+++ b/src/Tests/htmlformatterunittests.h
@@ -37,6 +37,9 @@ private slots:
     void commentTag();
     void commentTagSilent();
     void innerContentNewLine();
+    void formattedLineWithSelection_case1();
+    void formattedLineWithSelection_case2();
+    void formattedLineWithSelection_case3();
 };
 
 #endif // HTMLFORMATTERUNITTESTS_H

--- a/src/Tests/htmlformatterunittests.h
+++ b/src/Tests/htmlformatterunittests.h
@@ -27,10 +27,15 @@ public:
 
 private slots:
     void htmlLowerHeader();
+    void htmlLowerHeaderSilent();
     void htmlUpperHeader();
+    void htmlUpperHeaderSilent();
     void emptyFullTag();
+    void emptyFullTagSilent();
     void attributeWithUrl();
+    void attributeWithUrlSilent();
     void commentTag();
+    void commentTagSilent();
 };
 
 #endif // HTMLFORMATTERUNITTESTS_H

--- a/src/Tests/htmlformatterunittests.h
+++ b/src/Tests/htmlformatterunittests.h
@@ -36,6 +36,7 @@ private slots:
     void attributeWithUrlSilent();
     void commentTag();
     void commentTagSilent();
+    void innerContentNewLine();
 };
 
 #endif // HTMLFORMATTERUNITTESTS_H

--- a/src/Tests/jsonformatterunittests.cpp
+++ b/src/Tests/jsonformatterunittests.cpp
@@ -29,6 +29,16 @@ void JsonFormatterUnitTests::stringOnly()
     QCOMPARE(result, QString("<font color=\"#800000\">\"string\"</font>"));
 }
 
+void JsonFormatterUnitTests::stringOnlySilent()
+{
+    JsonFormatter formatter;
+    auto result = formatter.silentFormat("\"string\"");
+    QCOMPARE(result.size(), 1);
+    auto first = result.value(0);
+    QCOMPARE(first->line(), "\"string\"");
+    QCOMPARE(first->formattedLine(4), QString("<font color=\"#800000\">\"string\"</font>"));
+}
+
 void JsonFormatterUnitTests::objectOnly()
 {
     JsonFormatter formatter;
@@ -37,6 +47,19 @@ void JsonFormatterUnitTests::objectOnly()
 &nbsp;&nbsp;&nbsp;&nbsp;<font color="#750f8a">"property"</font>:&nbsp;<font color="#cc7700">35</font>
 <font color="black">}</font>)a");
     QCOMPARE(result, expectedResult);
+}
+
+void JsonFormatterUnitTests::objectOnlySilent()
+{
+    JsonFormatter formatter;
+    auto result = formatter.silentFormat("{\"property\":35}");
+    QCOMPARE(result.size(), 3);
+    QCOMPARE(result.value(0)->formattedLine(4), R"(<font color="black">{</font>)");
+    QCOMPARE(result.value(0)->line(), "{");
+    QCOMPARE(result.value(1)->formattedLine(4), R"(&nbsp;&nbsp;&nbsp;&nbsp;<font color="#750f8a">"property"</font>:&nbsp;<font color="#cc7700">35</font>)");
+    QCOMPARE(result.value(1)->line(), "\"property\":35");
+    QCOMPARE(result.value(2)->formattedLine(4), R"(<font color="black">}</font>)");
+    QCOMPARE(result.value(2)->line(), "}");
 }
 
 void JsonFormatterUnitTests::objectOnlyMoreProperties()
@@ -49,6 +72,24 @@ void JsonFormatterUnitTests::objectOnlyMoreProperties()
 &nbsp;&nbsp;&nbsp;&nbsp;<font color="#750f8a">"third"</font>:&nbsp;<font color="#cc7700">45</font>
 <font color="black">}</font>)a");
     QCOMPARE(result, expectedResult);
+}
+
+void JsonFormatterUnitTests::objectOnlyMorePropertiesSilent()
+{
+    JsonFormatter formatter;
+    auto result = formatter.silentFormat("{\"first\": 35, \"second\": 89, \"third\": 45}");
+    QCOMPARE(result.size(), 5);
+    QCOMPARE(result.value(0)->formattedLine(4), R"(<font color="black">{</font>)");
+    QCOMPARE(result.value(1)->formattedLine(4), R"(&nbsp;&nbsp;&nbsp;&nbsp;<font color="#750f8a">"first"</font>:&nbsp;<font color="#cc7700">35</font>,)");
+    QCOMPARE(result.value(2)->formattedLine(4), R"(&nbsp;&nbsp;&nbsp;&nbsp;<font color="#750f8a">"second"</font>:&nbsp;<font color="#cc7700">89</font>,)");
+    QCOMPARE(result.value(3)->formattedLine(4), R"(&nbsp;&nbsp;&nbsp;&nbsp;<font color="#750f8a">"third"</font>:&nbsp;<font color="#cc7700">45</font>)");
+    QCOMPARE(result.value(4)->formattedLine(4), R"(<font color="black">}</font>)");
+
+    QCOMPARE(result.value(0)->line(), "{");
+    QCOMPARE(result.value(1)->line(), "\"first\":35,");
+    QCOMPARE(result.value(2)->line(), "\"second\":89,");
+    QCOMPARE(result.value(3)->line(), "\"third\":45");
+    QCOMPARE(result.value(4)->line(), "}");
 }
 
 void JsonFormatterUnitTests::objectOnlyMorePropertiesWithNewLines()

--- a/src/Tests/jsonformatterunittests.cpp
+++ b/src/Tests/jsonformatterunittests.cpp
@@ -104,6 +104,24 @@ void JsonFormatterUnitTests::objectOnlyMorePropertiesWithNewLines()
     QCOMPARE(result, expectedResult);
 }
 
+void JsonFormatterUnitTests::objectOnlyMorePropertiesWithNewLinesSilent()
+{
+    JsonFormatter formatter;
+    auto result = formatter.silentFormat("{\"first\": 35,\n \"second\": 89,\n \"third\": 45}");
+    QCOMPARE(result.size(), 5);
+    QCOMPARE(result.value(0)->formattedLine(4), R"(<font color="black">{</font>)");
+    QCOMPARE(result.value(1)->formattedLine(4), R"(&nbsp;&nbsp;&nbsp;&nbsp;<font color="#750f8a">"first"</font>:&nbsp;<font color="#cc7700">35</font>,)");
+    QCOMPARE(result.value(2)->formattedLine(4), R"(&nbsp;&nbsp;&nbsp;&nbsp;<font color="#750f8a">"second"</font>:&nbsp;<font color="#cc7700">89</font>,)");
+    QCOMPARE(result.value(3)->formattedLine(4), R"(&nbsp;&nbsp;&nbsp;&nbsp;<font color="#750f8a">"third"</font>:&nbsp;<font color="#cc7700">45</font>)");
+    QCOMPARE(result.value(4)->formattedLine(4), R"(<font color="black">}</font>)");
+
+    QCOMPARE(result.value(0)->line(), "{");
+    QCOMPARE(result.value(1)->line(), "\"first\":35,");
+    QCOMPARE(result.value(2)->line(), "\"second\":89,");
+    QCOMPARE(result.value(3)->line(), "\"third\":45");
+    QCOMPARE(result.value(4)->line(), "}");
+}
+
 void JsonFormatterUnitTests::objectOnlyMorePropertiesWithTabulators()
 {
     JsonFormatter formatter;
@@ -116,6 +134,24 @@ void JsonFormatterUnitTests::objectOnlyMorePropertiesWithTabulators()
     QCOMPARE(result, expectedResult);
 }
 
+void JsonFormatterUnitTests::objectOnlyMorePropertiesWithTabulatorsSilent()
+{
+    JsonFormatter formatter;
+    auto result = formatter.silentFormat("{\"first\": 35,\t \"second\": 89,\t \"third\": 45}");
+    QCOMPARE(result.size(), 5);
+    QCOMPARE(result.value(0)->formattedLine(4), R"(<font color="black">{</font>)");
+    QCOMPARE(result.value(1)->formattedLine(4), R"(&nbsp;&nbsp;&nbsp;&nbsp;<font color="#750f8a">"first"</font>:&nbsp;<font color="#cc7700">35</font>,)");
+    QCOMPARE(result.value(2)->formattedLine(4), R"(&nbsp;&nbsp;&nbsp;&nbsp;<font color="#750f8a">"second"</font>:&nbsp;<font color="#cc7700">89</font>,)");
+    QCOMPARE(result.value(3)->formattedLine(4), R"(&nbsp;&nbsp;&nbsp;&nbsp;<font color="#750f8a">"third"</font>:&nbsp;<font color="#cc7700">45</font>)");
+    QCOMPARE(result.value(4)->formattedLine(4), R"(<font color="black">}</font>)");
+
+    QCOMPARE(result.value(0)->line(), "{");
+    QCOMPARE(result.value(1)->line(), "\"first\":35,");
+    QCOMPARE(result.value(2)->line(), "\"second\":89,");
+    QCOMPARE(result.value(3)->line(), "\"third\":45");
+    QCOMPARE(result.value(4)->line(), "}");
+}
+
 void JsonFormatterUnitTests::arrayOnly()
 {
     JsonFormatter formatter;
@@ -124,6 +160,21 @@ void JsonFormatterUnitTests::arrayOnly()
 &nbsp;&nbsp;&nbsp;&nbsp;<font color="#cc7700">1</font>
 <font color="black">]</font>)a");
     QCOMPARE(result, expectedResult);
+}
+
+void JsonFormatterUnitTests::arrayOnlySilent()
+{
+    JsonFormatter formatter;
+    auto result = formatter.silentFormat("[1]");
+
+    QCOMPARE(result.size(), 3);
+    QCOMPARE(result.value(0)->formattedLine(4), R"(<font color="black">[</font>)");
+    QCOMPARE(result.value(1)->formattedLine(4), R"(&nbsp;&nbsp;&nbsp;&nbsp;<font color="#cc7700">1</font>)");
+    QCOMPARE(result.value(2)->formattedLine(4), R"(<font color="black">]</font>)");
+
+    QCOMPARE(result.value(0)->line(), "[");
+    QCOMPARE(result.value(1)->line(), "1");
+    QCOMPARE(result.value(2)->line(), "]");
 }
 
 void JsonFormatterUnitTests::arrayInObject()
@@ -142,6 +193,33 @@ void JsonFormatterUnitTests::arrayInObject()
     QCOMPARE(result, QString(str));
 }
 
+void JsonFormatterUnitTests::arrayInObjectSilent()
+{
+    JsonFormatter formatter;
+    auto result = formatter.silentFormat("{\"items\": [1, 2, 3, 5, 6] }");
+
+    QCOMPARE(result.size(), 9);
+    QCOMPARE(result.value(0)->formattedLine(4), R"(<font color="black">{</font>)");
+    QCOMPARE(result.value(1)->formattedLine(4), R"(&nbsp;&nbsp;&nbsp;&nbsp;<font color="#750f8a">"items"</font>:&nbsp;<font color="black">[</font>)");
+    QCOMPARE(result.value(2)->formattedLine(4), R"(&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<font color="#cc7700">1</font>,)");
+    QCOMPARE(result.value(3)->formattedLine(4), R"(&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<font color="#cc7700">2</font>,)");
+    QCOMPARE(result.value(4)->formattedLine(4), R"(&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<font color="#cc7700">3</font>,)");
+    QCOMPARE(result.value(5)->formattedLine(4), R"(&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<font color="#cc7700">5</font>,)");
+    QCOMPARE(result.value(6)->formattedLine(4), R"(&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<font color="#cc7700">6</font>)");
+    QCOMPARE(result.value(7)->formattedLine(4), R"(&nbsp;&nbsp;&nbsp;&nbsp;<font color="black">]</font>)");
+    QCOMPARE(result.value(8)->formattedLine(4), R"(<font color="black">}</font>)");
+
+    QCOMPARE(result.value(0)->line(), "{");
+    QCOMPARE(result.value(1)->line(), "\"items\":[");
+    QCOMPARE(result.value(2)->line(), "1,");
+    QCOMPARE(result.value(3)->line(), "2,");
+    QCOMPARE(result.value(4)->line(), "3,");
+    QCOMPARE(result.value(5)->line(), "5,");
+    QCOMPARE(result.value(6)->line(), "6");
+    QCOMPARE(result.value(7)->line(), "]");
+    QCOMPARE(result.value(8)->line(), "}");
+}
+
 void JsonFormatterUnitTests::objectWithNegativeDigit()
 {
     JsonFormatter formatter;
@@ -150,6 +228,21 @@ void JsonFormatterUnitTests::objectWithNegativeDigit()
 &nbsp;&nbsp;&nbsp;&nbsp;<font color="#750f8a">"property"</font>:&nbsp;<font color="#cc7700">-35</font>
 <font color="black">}</font>)a");
     QCOMPARE(result, expectedResult);
+}
+
+void JsonFormatterUnitTests::objectWithNegativeDigitSilent()
+{
+    JsonFormatter formatter;
+    auto result = formatter.silentFormat("{\"property\":-35}");
+
+    QCOMPARE(result.size(), 3);
+    QCOMPARE(result.value(0)->formattedLine(4), R"(<font color="black">{</font>)");
+    QCOMPARE(result.value(1)->formattedLine(4), R"(&nbsp;&nbsp;&nbsp;&nbsp;<font color="#750f8a">"property"</font>:&nbsp;<font color="#cc7700">-35</font>)");
+    QCOMPARE(result.value(2)->formattedLine(4), R"(<font color="black">}</font>)");
+
+    QCOMPARE(result.value(0)->line(), "{");
+    QCOMPARE(result.value(1)->line(), "\"property\":-35");
+    QCOMPARE(result.value(2)->line(), "}");
 }
 
 void JsonFormatterUnitTests::objectWithHexDigit()
@@ -162,6 +255,21 @@ void JsonFormatterUnitTests::objectWithHexDigit()
     QCOMPARE(result, expectedResult);
 }
 
+void JsonFormatterUnitTests::objectWithHexDigitSilent()
+{
+    JsonFormatter formatter;
+    auto result = formatter.silentFormat("{\"property\":0xF79100}");
+
+    QCOMPARE(result.size(), 3);
+    QCOMPARE(result.value(0)->formattedLine(4), R"(<font color="black">{</font>)");
+    QCOMPARE(result.value(1)->formattedLine(4), R"(&nbsp;&nbsp;&nbsp;&nbsp;<font color="#750f8a">"property"</font>:&nbsp;<font color="#cc7700">0xF79100</font>)");
+    QCOMPARE(result.value(2)->formattedLine(4), R"(<font color="black">}</font>)");
+
+    QCOMPARE(result.value(0)->line(), "{");
+    QCOMPARE(result.value(1)->line(), "\"property\":0xF79100");
+    QCOMPARE(result.value(2)->line(), "}");
+}
+
 void JsonFormatterUnitTests::objectWithDoubleDigit()
 {
     JsonFormatter formatter;
@@ -170,4 +278,19 @@ void JsonFormatterUnitTests::objectWithDoubleDigit()
 &nbsp;&nbsp;&nbsp;&nbsp;<font color="#750f8a">"property"</font>:&nbsp;<font color="#cc7700">0.05</font>
 <font color="black">}</font>)a");
     QCOMPARE(result, expectedResult);
+}
+
+void JsonFormatterUnitTests::objectWithDoubleDigitSilent()
+{
+    JsonFormatter formatter;
+    auto result = formatter.silentFormat("{\"property\":0.05}");
+
+    QCOMPARE(result.size(), 3);
+    QCOMPARE(result.value(0)->formattedLine(4), R"(<font color="black">{</font>)");
+    QCOMPARE(result.value(1)->formattedLine(4), R"(&nbsp;&nbsp;&nbsp;&nbsp;<font color="#750f8a">"property"</font>:&nbsp;<font color="#cc7700">0.05</font>)");
+    QCOMPARE(result.value(2)->formattedLine(4), R"(<font color="black">}</font>)");
+
+    QCOMPARE(result.value(0)->line(), "{");
+    QCOMPARE(result.value(1)->line(), "\"property\":0.05");
+    QCOMPARE(result.value(2)->line(), "}");
 }

--- a/src/Tests/jsonformatterunittests.h
+++ b/src/Tests/jsonformatterunittests.h
@@ -27,8 +27,11 @@ public:
 
 private slots:
     void stringOnly();
+    void stringOnlySilent();
     void objectOnly();
+    void objectOnlySilent();
     void objectOnlyMoreProperties();
+    void objectOnlyMorePropertiesSilent();
     void objectOnlyMorePropertiesWithNewLines();
     void objectOnlyMorePropertiesWithTabulators();
     void arrayOnly();

--- a/src/Tests/jsonformatterunittests.h
+++ b/src/Tests/jsonformatterunittests.h
@@ -33,12 +33,19 @@ private slots:
     void objectOnlyMoreProperties();
     void objectOnlyMorePropertiesSilent();
     void objectOnlyMorePropertiesWithNewLines();
+    void objectOnlyMorePropertiesWithNewLinesSilent();
     void objectOnlyMorePropertiesWithTabulators();
+    void objectOnlyMorePropertiesWithTabulatorsSilent();
     void arrayOnly();
+    void arrayOnlySilent();
     void arrayInObject();
+    void arrayInObjectSilent();
     void objectWithNegativeDigit();
+    void objectWithNegativeDigitSilent();
     void objectWithHexDigit();
+    void objectWithHexDigitSilent();
     void objectWithDoubleDigit();
+    void objectWithDoubleDigitSilent();
 };
 
 #endif // JSONFORMATTERUNITTESTS_H

--- a/src/Tests/xmlformatterunittests.cpp
+++ b/src/Tests/xmlformatterunittests.cpp
@@ -1,0 +1,34 @@
+#include "xmlformatterunittests.h"
+#include "../Formatters/xmlformatter.h"
+
+XmlFormatterUnitTests::XmlFormatterUnitTests(QObject *parent)
+    : QObject{parent}
+{}
+
+void XmlFormatterUnitTests::xmlOnlyHeaderSilent()
+{
+    XmlFormatter formatter;
+    auto result = formatter.silentFormat(R"(<?xml version="1.0" encoding="UTF-8"?>)");
+
+    QCOMPARE(result.size(), 1);
+    QCOMPARE(result.value(0)->formattedLine(1), R"(<font color="gray">&lt;?xml version="1.0" encoding="UTF-8"?&gt;</font>)");
+}
+
+void XmlFormatterUnitTests::xmlEmptyTagSilent()
+{
+    XmlFormatter formatter;
+    auto result = formatter.silentFormat(
+        R"(
+<?xml version="1.0" encoding="UTF-8"?>
+<doc>
+</doc>
+)"
+    );
+
+    QCOMPARE(result.size(), 3);
+    QCOMPARE(result.value(0)->formattedLine(1), R"(<font color="gray">&lt;?xml version="1.0" encoding="UTF-8"?&gt;</font>)");
+    QCOMPARE(result.value(1)->formattedLine(1), R"(<font color="#8812a1">&lt;doc&gt;</font>)");
+    QCOMPARE(result.value(2)->formattedLine(1), R"(<font color="#8812a1">&lt;/doc&gt;</font>)");
+}
+
+

--- a/src/Tests/xmlformatterunittests.cpp
+++ b/src/Tests/xmlformatterunittests.cpp
@@ -31,4 +31,36 @@ void XmlFormatterUnitTests::xmlEmptyTagSilent()
     QCOMPARE(result.value(2)->formattedLine(1), R"(<font color="#8812a1">&lt;/doc&gt;</font>)");
 }
 
+void XmlFormatterUnitTests::xmlNestedEmptyTagSilent()
+{
+    XmlFormatter formatter;
+    auto result = formatter.silentFormat(
+        R"(
+<?xml version="1.0" encoding="UTF-8"?>
+<doc>
+    <part>
+    </part>
+</doc>
+)"
+        );
+
+    QCOMPARE(result.size(), 5);
+    QCOMPARE(result.value(0)->formattedLine(1), R"(<font color="gray">&lt;?xml version="1.0" encoding="UTF-8"?&gt;</font>)");
+    QCOMPARE(result.value(1)->formattedLine(1), R"(<font color="#8812a1">&lt;doc&gt;</font>)");
+    QCOMPARE(result.value(2)->formattedLine(1), R"(&nbsp;<font color="#8812a1">&lt;part&gt;</font>)");
+    QCOMPARE(result.value(3)->formattedLine(1), R"(&nbsp;<font color="#8812a1">&lt;/part&gt;</font>)");
+    QCOMPARE(result.value(4)->formattedLine(1), R"(<font color="#8812a1">&lt;/doc&gt;</font>)");
+}
+
+void XmlFormatterUnitTests::attibuteWithUrlSilent()
+{
+    XmlFormatter formatter;
+    auto result = formatter.silentFormat(R"(<test attr="http://www.test.com"></test>)");
+
+    QCOMPARE(result.size(), 2);
+
+    QCOMPARE(result.value(0)->formattedLine(1), R"(<font color="#8812a1">&lt;test</font> <font color="#994500">attr=<font color="#2222dd">&quot;http://www.test.com&quot;</font>&gt;</font>)");
+    QCOMPARE(result.value(1)->formattedLine(1), R"(<font color="#8812a1">&lt;/test&gt;</font>)");
+}
+
 

--- a/src/Tests/xmlformatterunittests.cpp
+++ b/src/Tests/xmlformatterunittests.cpp
@@ -59,7 +59,7 @@ void XmlFormatterUnitTests::attibuteWithUrlSilent()
 
     QCOMPARE(result.size(), 2);
 
-    QCOMPARE(result.value(0)->formattedLine(1), R"(<font color="#8812a1">&lt;test</font> <font color="#994500">attr=<font color="#2222dd">&quot;http://www.test.com&quot;</font>&gt;</font>)");
+    QCOMPARE(result.value(0)->formattedLine(1), R"(<font color="#8812a1">&lt;test</font><font color="#994500"> attr=<font color="#2222dd">&quot;http://www.test.com&quot;</font>&gt;</font>)");
     QCOMPARE(result.value(1)->formattedLine(1), R"(<font color="#8812a1">&lt;/test&gt;</font>)");
 }
 

--- a/src/Tests/xmlformatterunittests.h
+++ b/src/Tests/xmlformatterunittests.h
@@ -1,0 +1,21 @@
+#ifndef XMLFORMATTERUNITTESTS_H
+#define XMLFORMATTERUNITTESTS_H
+
+#include <QObject>
+#include <QtTest/QtTest>
+
+class XmlFormatterUnitTests : public QObject
+{
+    Q_OBJECT
+public:
+    explicit XmlFormatterUnitTests(QObject *parent = nullptr);
+
+signals:
+
+private slots:
+    void xmlOnlyHeaderSilent();
+    void xmlEmptyTagSilent();
+
+};
+
+#endif // XMLFORMATTERUNITTESTS_H

--- a/src/Tests/xmlformatterunittests.h
+++ b/src/Tests/xmlformatterunittests.h
@@ -15,6 +15,8 @@ signals:
 private slots:
     void xmlOnlyHeaderSilent();
     void xmlEmptyTagSilent();
+    void xmlNestedEmptyTagSilent();
+    void attibuteWithUrlSilent();
 
 };
 

--- a/src/ViewModels/backendviewmodel.cpp
+++ b/src/ViewModels/backendviewmodel.cpp
@@ -51,6 +51,9 @@ void BackendViewModel::addNewRequest(bool forceSelectedAddedItem)
     request->setTextAdvisor(m_textAdviser);
     request->setSelectedItem(0); // select first empty field for new request
 
+    auto result = model->resultModel();
+    result->bodyModel()->setFontMetrics(m_bodyFontMetrics);
+
     m_requests->addItem(model);
 
     if (forceSelectedAddedItem) {
@@ -289,6 +292,9 @@ void BackendViewModel::importFromOpenApi(int index, bool replaceCurrent) noexcep
     auto request = model->requestModel();
     request->setTextAdvisor(m_textAdviser);
 
+    auto result = model->resultModel();
+    result->bodyModel()->setFontMetrics(m_bodyFontMetrics);
+
     auto summary = route->summary();
     if (!summary.isEmpty()) request->addItem(-1, HttpRequestViewModel::HttpRequestTypes::TitleType, route->summary());
 
@@ -370,6 +376,8 @@ void BackendViewModel::setResultBodyFontFamily(const QString &family, int fontSi
 {
     auto font = QFont(family, fontSize);
     m_bodyFontMetrics = QFontMetrics(font);
+
+    m_requests->fillFontMetrics(m_bodyFontMetrics);
 }
 
 void BackendViewModel::deleteCurrentRequest() noexcept

--- a/src/ViewModels/backendviewmodel.cpp
+++ b/src/ViewModels/backendviewmodel.cpp
@@ -366,6 +366,12 @@ void BackendViewModel::closeGlobalVariables() noexcept
     emit selectedGlobalVariableChanged();
 }
 
+void BackendViewModel::setResultBodyFontFamily(const QString &family, int fontSize) noexcept
+{
+    auto font = QFont(family, fontSize);
+    m_bodyFontMetrics = QFontMetrics(font);
+}
+
 void BackendViewModel::deleteCurrentRequest() noexcept
 {
     if (m_requests->singleRequest()) addNewRequest();

--- a/src/ViewModels/backendviewmodel.h
+++ b/src/ViewModels/backendviewmodel.h
@@ -16,6 +16,8 @@
 #ifndef BACKENDVIEWMODEL_H
 #define BACKENDVIEWMODEL_H
 
+#include <QFont>
+#include <QFontMetrics>
 #include <QObject>
 #include "../ViewModels/httpperformerviewmodel.h"
 #include "../ViewModels/textadvisorviewmodel.h"
@@ -47,6 +49,7 @@ class BackendViewModel : public QObject
     Q_PROPERTY(bool focusedHelpTextField READ focusedHelpTextField WRITE setFocusedHelpTextField NOTIFY focusedHelpTextFieldChanged FINAL)
     Q_PROPERTY(bool showGlobalVariablesPopup READ showGlobalVariablesPopup NOTIFY showGlobalVariablesPopupChanged FINAL)
     Q_PROPERTY(QString selectedGlobalVariable READ selectedGlobalVariable NOTIFY selectedGlobalVariableChanged FINAL)
+    Q_PROPERTY(QFontMetrics bodyFontMetrics READ bodyFontMetrics NOTIFY bodyFontMetricsChanged FINAL)
 
 private:
     HttpPerformerViewModel* m_requestPerformer { new HttpPerformerViewModel(this) };
@@ -68,6 +71,7 @@ private:
     bool m_focusedHelpTextField { false };
     bool m_showGlobalVariablesPopup { false };
     int m_selectedGlobalVariableIndex { -1 };
+    QFontMetrics m_bodyFontMetrics { QFontMetrics(QFont()) };
     QString m_selectedGlobalVariable { "" };
     QString m_globalVariablesPopupMode { "default" };
     const QString m_changeSelectedQueryCommand { "changeselectedquery" };
@@ -127,6 +131,8 @@ public:
     bool showGlobalVariablesPopup() const noexcept { return m_showGlobalVariablesPopup; }
     QString selectedGlobalVariable() const noexcept { return m_selectedGlobalVariable; }
 
+    QFontMetrics bodyFontMetrics() const noexcept { return m_bodyFontMetrics; }
+
     Q_INVOKABLE void addNewRequest(bool forceSelectedAddedItem = false);
     Q_INVOKABLE bool shortcutHandler(const QString& shortcut) noexcept;
     Q_INVOKABLE void refreshFindedIndex() noexcept;
@@ -137,6 +143,7 @@ public:
     Q_INVOKABLE void importFromOpenApi(int index, bool replaceCurrent) noexcept;
     Q_INVOKABLE void saveDownloadedFile(const QString& fileName) noexcept;
     Q_INVOKABLE void closeGlobalVariables() noexcept;
+    Q_INVOKABLE void setResultBodyFontFamily(const QString& family, int fontSize) noexcept;
 
     void deleteCurrentRequest() noexcept;
 
@@ -177,6 +184,7 @@ signals:
     void showGlobalVariablesPopupChanged();
     void selectedGlobalVariableChanged();
     void globalVariableSelected(int lastPosition);
+    void bodyFontMetricsChanged();
 
 private slots:
     void errorNotification(const QString& message, const QString& title);

--- a/src/ViewModels/globalmouseviewmodel.cpp
+++ b/src/ViewModels/globalmouseviewmodel.cpp
@@ -1,0 +1,52 @@
+#include <QGuiApplication>
+#include <QMouseEvent>
+#include "globalmouseviewmodel.h"
+
+GlobalMouseViewModel::GlobalMouseViewModel(QObject *parent)
+    : QObject{parent}
+{
+    QGuiApplication::instance()->installEventFilter(this);
+}
+
+bool GlobalMouseViewModel::eventFilter(QObject* watched, QEvent* event)
+{
+    if (!m_moveTracking) return QObject::eventFilter(watched, event);
+    if (!event->spontaneous()) return QObject::eventFilter(watched, event);
+
+    QEvent::Type eventType = event->type();
+    if (eventType == QEvent::MouseMove) {
+        auto mouseEvent = static_cast<QMouseEvent*>(event);
+        auto position = mouseEvent->position();
+        m_xCoordinate = position.x();
+        m_yCoordinate = position.y();
+        if (m_xCoordinate >= m_leftEdge && m_yCoordinate >= m_topEdge) {
+            emit mouseMoved(m_xCoordinate, m_yCoordinate);
+            return true;
+        }
+    }
+
+    //need to handle when mouse will be released for finish operation
+    if (m_moveTracking && eventType == QEvent::MouseButtonRelease) {
+        auto mouseEvent = static_cast<QMouseEvent*>(event);
+        auto button = mouseEvent->button();
+        if (button == Qt::RightButton) {
+            setMoveTracking(false);
+            return true;
+        }
+    }
+
+    if (m_moveTracking && eventType == QEvent::Wheel) {
+        setMoveTracking(false);
+        return true;
+    }
+
+    return QObject::eventFilter(watched, event);
+}
+
+void GlobalMouseViewModel::setMoveTracking(bool moveTracking) noexcept
+{
+    if (m_moveTracking == moveTracking) return;
+
+    m_moveTracking = moveTracking;
+    emit moveTrackingChanged();
+}

--- a/src/ViewModels/globalmouseviewmodel.h
+++ b/src/ViewModels/globalmouseviewmodel.h
@@ -1,0 +1,39 @@
+#ifndef GLOBALMOUSEVIEWMODEL_H
+#define GLOBALMOUSEVIEWMODEL_H
+
+#include <QObject>
+
+class GlobalMouseViewModel : public QObject
+{
+    Q_OBJECT
+    Q_PROPERTY(bool moveTracking READ moveTracking WRITE setMoveTracking NOTIFY moveTrackingChanged)
+    Q_PROPERTY(int xCoordinate READ xCoordinate NOTIFY xCoordinateChanged)
+    Q_PROPERTY(int yCoordinate READ yCoordinate NOTIFY yCoordinateChanged)
+
+private:
+    int m_leftEdge { 0 };
+    int m_topEdge { 0 };
+    int m_xCoordinate { 0 };
+    int m_yCoordinate { 0 };
+    bool m_moveTracking { false };
+
+public:
+    explicit GlobalMouseViewModel(QObject *parent = nullptr);
+
+    bool eventFilter(QObject* watched, QEvent* event);
+
+    bool moveTracking() const noexcept { return m_moveTracking; }
+    void setMoveTracking(bool moveTracking) noexcept;
+
+    int xCoordinate() const noexcept { return m_xCoordinate; }
+    int yCoordinate() const noexcept { return m_yCoordinate; }
+
+signals:
+    void mouseMoved(int x, int y);
+    void moveTrackingChanged();
+    void xCoordinateChanged();
+    void yCoordinateChanged();
+
+};
+
+#endif // GLOBALMOUSEVIEWMODEL_H

--- a/src/Views/HttpResultViewer.qml
+++ b/src/Views/HttpResultViewer.qml
@@ -334,22 +334,58 @@ Item {
                                     width: listStrings.width
                                     height: line.height
 
+                                    required property string currentLine
+                                    required property bool isFindIndex
+                                    required property int currentIndex
+                                    required property bool isSelectedLine
+
                                     Rectangle {
                                         color: "black"
                                         opacity: .05
                                         anchors.fill: parent
-                                        visible: isFindIndex
+                                        visible: parent.isFindIndex
+                                    }
+                                    Rectangle {
+                                        color: "black"
+                                        opacity: .05
+                                        anchors.fill: parent
+                                        visible: parent.isSelectedLine
                                     }
                                     Text {
                                         id: line
                                         leftPadding: 4
                                         rightPadding: 10
                                         textFormat: viewModel.isFormatting ? Text.RichText : Text.PlainText
-                                        text: currentLine
+                                        text: parent.currentLine
                                         width: bodyContainer.width
                                         wrapMode: Text.Wrap
                                         font.pointSize: 9
                                     }
+
+                                    MouseArea {
+                                        anchors.fill: parent
+                                        acceptedButtons: Qt.RightButton
+                                        onPressed: {
+                                            if(!globalMouseViewModel.moveTracking) globalMouseViewModel.moveTracking = true;
+
+                                            viewModel.bodyModel.selectStartLine(parent.currentIndex);
+                                        }
+                                    }
+                                }
+                            }
+
+                            Connections {
+                                id: connection
+                                target: globalMouseViewModel
+                                function onMouseMoved(x, y) {
+                                    const point = listStrings.mapFromItem(root, x, y);
+                                    const child = listStrings.contentItem.childAt(point.x, point.y - 34 + listStrings.contentY);
+                                    if (!child) return;
+
+                                    const positionY = (point.y + listStrings.contentY) - 34 - child.y;
+                                    if (!viewModel.bodyModel.lineStarted) viewModel.bodyModel.selectStartLine(child.currentIndex);
+
+                                    viewModel.bodyModel.selectLine(child.currentIndex, child.width, child.height, point.x, positionY, viewModel.isFormatting);
                                 }
                             }
                         }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -30,6 +30,7 @@
 #include "ListModels/globalvariableslistmodel.h"
 #include "ListModels/responsebodylistmodel.h"
 #include "ViewModels/globaleventhandlermodel.h"
+#include "ViewModels/globalmouseviewmodel.h"
 #ifdef QT_DEBUG
 #include <QtTest/QtTest>
 #include "Tests/jsonformatterunittests.h"
@@ -104,6 +105,7 @@ void registerQmlTypes() {
     qmlRegisterType<GlobalVariablesListModel>("ArdorQuery.Backend", 1, 0, "GlobalVariablesListModel");
     qmlRegisterType<ResponseBodyListModel>("ArdorQuery.Backend", 1, 0, "ResponseBodyListModel");
     qmlRegisterType<GlobalEventHandlerModel>("ArdorQuery.Backend", 1, 0, "GlobalEventHandlerModel");
+    qmlRegisterType<GlobalMouseViewModel>("ArdorQuery.Backend", 1, 0, "GlobalMouseViewModel");
 }
 
 void adjustmentLocalStorage() {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -38,6 +38,7 @@
 #include "Tests/textadvisorviewmodelunittests.h"
 #include "Tests/globalvariablesunittest.h"
 #include "Tests/cssformatterunittests.h"
+#include "Tests/xmlformatterunittests.h"
 #endif
 
 void registerQmlTypes();
@@ -125,5 +126,6 @@ void runTest(int argc, char *argv[]) {
     QTest::qExec(new TextAdvisorViewModelUnitTests, argc - 1, argv);
     QTest::qExec(new GlobalVariablesUnitTest, argc - 1, argv);
     QTest::qExec(new CssFormatterUnitTests, argc - 1, argv);
+    QTest::qExec(new XmlFormatterUnitTests, argc - 1, argv);
 }
 #endif

--- a/src/main.qml
+++ b/src/main.qml
@@ -245,6 +245,17 @@ ApplicationWindow {
         }
     }
 
+    GlobalMouseViewModel {
+        id: globalMouseViewModel
+    }
+
+    Text {
+        id: emptyText
+        Component.onCompleted: {
+            backend.setResultBodyFontFamily(emptyText.font.family, emptyText.font.pointSize);
+        }
+    }
+
     onActiveFocusItemChanged: {
         if (!window.activeFocusItem) globalEventHandler.clear();
     }


### PR DESCRIPTION
Currently, formatters immediately turn a string with all data into a string with formatted data. Now I came to the understanding that another structure is needed, where each string will contain the original string with metadata to create a formatted string. This will be necessary for more subtle work with strings in the control for displaying the result. This will allow both the selection of the string and the highlighting of the found elements of the string.